### PR TITLE
Fix length check in draw_multi_line_park_name_text_block

### DIFF
--- a/display/park/park_details.py
+++ b/display/park/park_details.py
@@ -129,7 +129,7 @@ def draw_multi_line_park_name_text_block(matrix, text_lines):
     # Start baseline so the entire block is vertically centered.
     current_y =  font_height
     for line in text_lines:
-        if len(text_lines) is 1:
+        if len(text_lines) == 1:
             if matrix.height == 32:
                 current_y = int(current_y * 1.5)
             else:


### PR DESCRIPTION
## Summary
- correct comparison for single-line text blocks

## Testing
- `python -m compileall -q display/park/park_details.py`
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp>=3.11.13)*

------
https://chatgpt.com/codex/tasks/task_e_686979adcbb083238813965b2009121f