### PR TITLE
Fix bug in park name rendering

### DIFF
--- a/display/park/park_details.py
+++ b/display/park/park_details.py
@@ -129,7 +129,7 @@ def draw_multi_line_park_name_text_block(matrix, text_lines):
     # Start baseline so the entire block is vertically centered.
     current_y =  font_height
     for line in text_lines:
-        if len(text_lines) is 1:
+        if len(text_lines) == 1:
             if matrix.height == 32:
                 current_y = int(current_y * 1.5)
             else:


### PR DESCRIPTION
## Summary
- fix `is`/`==` mix-up when centering park name

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854bef7b7b083239935c5e5aa92a297