### PR TITLE
Clean up unused imports

### DIFF
--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -1,5 +1,3 @@
-from types import MappingProxyType
-
 import requests
 
 import asyncio


### PR DESCRIPTION
## Summary
- remove unused MappingProxyType import from `disney_api`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_68698284e010832385cb5630684beb69