### PR TITLE
Improve pytz stub with DST

### DIFF
--- a/pytz.py
+++ b/pytz.py
@@ -1,12 +1,54 @@
-from datetime import timezone as dt_timezone, timedelta
+from datetime import timezone as dt_timezone, timedelta, datetime, tzinfo
+
+
+class _USEastern(tzinfo):
+    """Very small tzinfo implementation for the US/Eastern time zone."""
+
+    def __init__(self, name: str = "US/Eastern"):
+        self.name = name
+
+    def __repr__(self):
+        return f"<Timezone {self.name}>"
+
+    def _is_dst(self, dt: datetime) -> bool:
+        """Determine if ``dt`` is in daylight saving time."""
+        if dt is None:
+            return False
+
+        # Work with naive datetime for calculations
+        dt = dt.replace(tzinfo=None)
+        year = dt.year
+
+        # DST starts at 2am on the second Sunday in March
+        start = datetime(year, 3, 8)
+        start += timedelta(days=(6 - start.weekday()))  # move to Sunday
+        start = start.replace(hour=2)
+
+        # DST ends at 2am on the first Sunday in November
+        end = datetime(year, 11, 1)
+        end += timedelta(days=(6 - end.weekday()))
+        end = end.replace(hour=2)
+
+        return start <= dt < end
+
+    def utcoffset(self, dt: datetime) -> timedelta:
+        return timedelta(hours=-5) + self.dst(dt)
+
+    def dst(self, dt: datetime) -> timedelta:
+        if self._is_dst(dt):
+            return timedelta(hours=1)
+        return timedelta(0)
+
+    def tzname(self, dt: datetime) -> str:  # pragma: no cover - simple accessor
+        return self.name
 
 
 def timezone(name: str):
     if name == "UTC":
         return dt_timezone.utc
     if name in {"US/Eastern", "America/New_York"}:
-        # Eastern Time is UTC-5 in winter (non-DST) which is enough for tests
-        return dt_timezone(timedelta(hours=-5), name)
+        # Return a timezone with simple DST logic.
+        return _USEastern(name)
     raise NotImplementedError(name)
 
 utc = dt_timezone.utc

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,3 +25,7 @@ def test_deep_update():
 def test_get_eastern():
     eastern_time = get_eastern("2024-01-01T12:00:00Z")
     assert eastern_time.endswith("07:00 AM")
+
+    # During daylight saving time the offset should be UTC-4
+    dst_time = get_eastern("2024-07-01T12:00:00Z")
+    assert dst_time.endswith("08:00 AM")


### PR DESCRIPTION
## Summary
- improve the pytz stub to return a timezone object that switches between UTC‑5 and UTC‑4 based on a simple DST calculation
- extend `test_get_eastern` to verify DST support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869850f24dc8323a66c7132d0fb000b