### PR TITLE
feat: WebSocket live updates, multi-park support, and display improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+config.json
+.idea/
+build/
+dist/
+__pycache__/
+*.pyc
+.venv/
+*.egg-info/
+.coverage
+logs/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .coverage
 logs/
 .DS_Store
+README.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Disney (Emulated) 64x32",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/disney.py",
+      "args": ["--emulated", "--led-cols=64", "--led-rows=32"],
+      "cwd": "${workspaceFolder}",
+      "env": { "PYTHONUNBUFFERED": "1" }
+    },
+    {
+      "name": "Disney (Emulated) 64x64",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/disney.py",
+      "args": ["--emulated", "--led-cols=64", "--led-rows=64"],
+      "cwd": "${workspaceFolder}",
+      "env": { "PYTHONUNBUFFERED": "1" }
+    },
+    {
+      "name": "Pytest",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["-v"],
+      "cwd": "${workspaceFolder}",
+      "env": { "PYTHONUNBUFFERED": "1" }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,17 +29,26 @@ pipreqs . --force
 
 ## Architecture
 
-The application is a continuous display loop that fetches Disney World attraction wait times and renders them on an RGB LED matrix. Two threads run concurrently:
+The application is a continuous display loop that fetches Disney World attraction wait times and renders them on an RGB LED matrix. Two or three threads run concurrently:
 
 - **Main thread** (`disney.py`): Drives the display loop — renders Mickey logo → optional trip countdown → park title screen → attraction wait times, cycling indefinitely.
-- **Background thread** (`updater/data_updater.py:live_data_updater`): Fetches updated live wait times every 5 minutes and updates the shared `parks_data` list in-place.
+- **REST thread** (`updater/data_updater.py:live_data_updater`): Fetches live wait times every `update_interval` seconds (5 min) and updates the shared `parks_data` list in-place. Always does the initial fetch/populate, even in WebSocket mode.
+- **WebSocket thread** (`updater/websocket_updater.py:websocket_live_updater`), started only when `config.json`'s `themeparks_api_key` is set or `websocket_only: true`: maintains a persistent connection to `wss://ws.themeparks.wiki/v1/live` for real-time attraction updates. When active, the REST thread skips attraction polling (`use_websocket=True`) but keeps refreshing weather and servicing deferred schedule fetches.
 
 ### Data flow
 
 1. `api/disney_api.py:fetch_list_of_disney_world_parks()` — fetches the 4 WDW theme parks (excluding water parks) from the ThemeParks Wiki API.
 2. `api/disney_api.py:fetch_parks_and_attractions()` — fetches each park's attraction list; initial wait times are empty placeholders.
-3. Background thread calls `fetch_live_data()` (async, via `aiohttp`) to concurrently fetch live wait times for all attractions, then `merge_live_data()` merges them into the shared list.
+3. Live wait times come from one `api/disney_api.py:fetch_park_live_data()` call per park (`/entity/{parkId}/live` — all children in one request, not one call per attraction), parsed by `build_live_updates()`/`parse_queue_wait()`, then merged into the shared list by `updater/data_updater.py:merge_live_data()`. In WebSocket mode, per-event updates arrive instead via `updater/websocket_updater.py:_apply_live_update()`, which reuses `parse_queue_wait()`; the per-park REST fetch still runs once at startup and after every WS reconnect.
 4. `api/weather.py` provides weather data per park, fetched via OpenWeatherMap (requires API key in `config.json`).
+
+### WebSocket resilience
+
+`updater/websocket_updater.py` maintains the live connection with several layered defenses (see git history on `feature/websocket` and its stack for the incident that motivated each):
+- `ws_connect(..., heartbeat=30, receive_timeout=120)` detects a dead socket and forces a reconnect within ~2 minutes.
+- A per-connection `_watchdog` task force-reconnects if zero messages arrive in a 5-minute window while any park is `operating` — catches a connection that's alive at the protocol level but has stopped streaming data.
+- Reconnect backoff (`_next_delay`) only resets to 5s after a connection stays up 60s+; otherwise it doubles (capped at 60s), so a connect-then-die loop can't hammer the server.
+- `attr["lastUpdatedTs"]`/`down_since` are stamped from the event's own `lastUpdated`, not receive time — confirmed present on all ATTRACTION/SHOW entries from the live API.
 
 ### Display layer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+# Run all tests
+pytest
+
+# Run a single test file
+pytest tests/api/test_disney_api.py
+
+# Run a single test by name
+pytest tests/api/test_disney_api.py::test_function_name
+
+# Run the app in emulator mode (no hardware required)
+./disney.py --emulated --led-cols=64 --led-rows=32
+
+# Run with specific board size
+./disney.py --emulated --led-cols=64 --led-rows=64
+
+# Check version
+python3 version.py
+
+# Update requirements (after adding/changing dependencies)
+pipreqs . --force
+```
+
+## Architecture
+
+The application is a continuous display loop that fetches Disney World attraction wait times and renders them on an RGB LED matrix. Two threads run concurrently:
+
+- **Main thread** (`disney.py`): Drives the display loop — renders Mickey logo → optional trip countdown → park title screen → attraction wait times, cycling indefinitely.
+- **Background thread** (`updater/data_updater.py:live_data_updater`): Fetches updated live wait times every 5 minutes and updates the shared `parks_data` list in-place.
+
+### Data flow
+
+1. `api/disney_api.py:fetch_list_of_disney_world_parks()` — fetches the 4 WDW theme parks (excluding water parks) from the ThemeParks Wiki API.
+2. `api/disney_api.py:fetch_parks_and_attractions()` — fetches each park's attraction list; initial wait times are empty placeholders.
+3. Background thread calls `fetch_live_data()` (async, via `aiohttp`) to concurrently fetch live wait times for all attractions, then `merge_live_data()` merges them into the shared list.
+4. `api/weather.py` provides weather data per park, fetched via OpenWeatherMap (requires API key in `config.json`).
+
+### Display layer
+
+All rendering lives under `display/`. Fonts are loaded once at startup by `display/display.py:initialize_fonts()` into the module-level `loaded_fonts` dict, keyed by board height (32 or 64). Each sub-module (`park/park_details.py`, `attractions/attraction_info.py`, `countdown/countdown.py`, `startup.py`) imports from that shared dict. Font sizes and paths differ between 64-row and 32-row boards.
+
+### Driver abstraction
+
+`driver/` wraps both `rgbmatrix` (real hardware, Raspberry Pi only) and `RGBMatrixEmulator` (software). The `driver/__init__.py` auto-selects based on whether hardware is available. `driver/mode.py` defines the `DriverMode` enum. Use `driver.is_emulated()` to branch on hardware vs. emulator.
+
+### Configuration
+
+`config.json` (gitignored; copy from `config.json-example`) controls:
+- `trip_countdown.enabled` — show/hide countdown
+- `trip_countdown.trip_dates` — list of ISO date strings (`YYYY-MM-DD`); supports multiple trips
+- `trip_countdown.trip_date` — legacy single-date fallback
+- `weather.apikey` — OpenWeatherMap API key
+- `debug` — enables verbose logging
+
+### Testing
+
+Tests use `pytest`. The `tests/stubs/conftest.py` patches `builtins.open` to intercept `config.json` reads (returns a dummy config) and stubs out the `driver` module entirely so tests run without hardware or the `rgbmatrix` binary. Stub modules for `aiohttp`, `requests`, `pyowm`, and `pytz` live in `tests/stubs/`.
+
+The `operating` field on a park dict is set by `update_parks_operating_status()` — a park is considered operating only if at least one attraction has a non-null wait time and `OPERATING` status. The main loop skips parks where `operating` is falsy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,11 @@ All rendering lives under `display/`. Fonts are loaded once at startup by `displ
 
 Tests use `pytest`. The `tests/stubs/conftest.py` patches `builtins.open` to intercept `config.json` reads (returns a dummy config) and stubs out the `driver` module entirely so tests run without hardware or the `rgbmatrix` binary. Stub modules for `aiohttp`, `requests`, `pyowm`, and `pytz` live in `tests/stubs/`.
 
-The `operating` field on a park dict is set by `update_parks_operating_status()` — a park is considered operating only if at least one attraction has a non-null wait time and `OPERATING` status. The main loop skips parks where `operating` is falsy.
+The `operating` field on a park dict is set by `update_parks_operating_status()` — a park is considered operating only if at least one attraction has a non-null wait time and `OPERATING` status. The main loop skips parks where `operating` is falsy. Its `fetch_schedules` flag controls whether a closed→open transition fetches the park schedule immediately (blocking HTTP) or only sets `schedule_refresh_needed`; the WebSocket thread always passes `fetch_schedules=False` (never block the asyncio event loop) and the REST thread services the flag on its next 5-minute cycle.
+
+### Gotchas
+
+- The app must run from the repo root — font paths (`assets/fonts/...`) and `config.json`/`emulator_config.json` are resolved relative to the cwd.
+- The emulator's browser adapter binds port 8888 (`emulator_config.json`); a second instance fails with `[Errno 48] Address already in use`.
+- The ThemeParks.wiki WS server closes duplicate/rate-limited connections with close code 4029; `ws.close_code` is logged when the receive loop ends.
+- macOS has no GNU `timeout`; use `perl -e 'alarm N; exec "python3", @ARGV' disney.py ...` for time-boxed runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Tests use `pytest`. The `tests/stubs/conftest.py` patches `builtins.open` to int
 
 The `operating` field on a park dict is set by `update_parks_operating_status()` — a park is considered operating only if at least one attraction has a non-null wait time and `OPERATING` status. The main loop skips parks where `operating` is falsy. Its `fetch_schedules` flag controls whether a closed→open transition fetches the park schedule immediately (blocking HTTP) or only sets `schedule_refresh_needed`; the WebSocket thread always passes `fetch_schedules=False` (never block the asyncio event loop) and the REST thread services the flag on its next 5-minute cycle.
 
+Mutations of the shared `parks_data` structure (WS thread and REST thread) must hold `updater/shared.py:parks_data_lock` — but only for in-memory writes, never across HTTP calls. `merge_live_data` mutates attraction dicts in place and returns the same list; don't rebuild the list, that drops concurrent WS updates. The display thread reads without locking by design.
+
 ### Gotchas
 
 - The app must run from the repo root — font paths (`assets/fonts/...`) and `config.json`/`emulator_config.json` are resolved relative to the cwd.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 ![Tests](https://github.com/jc214809/LightningLane-Live-LED/actions/workflows/coverage.yml/badge.svg) [![codecov](https://codecov.io/gh/jc214809/LightningLane-Live-LED/graph/badge.svg)](https://codecov.io/gh/jc214809/LightningLane-Live-LED)
 
 
-LightningLane-Live-LED is a Python application designed to fetch and display wait times for attractions at Walt Disney World on an LED matrix display. It retrieves park and attraction data from the [ThemeParks Wiki API](https://api.themeparks.wiki) and dynamically renders ride information—including park names, ride names, and wait times—onto an LED matrix. The application supports both actual hardware and an emulator for testing purposes.
+LightningLane-Live-LED is a Python application designed to fetch and display wait times for attractions at Walt Disney World and other theme parks on an LED matrix display. It retrieves park and attraction data from the [ThemeParks Wiki API](https://api.themeparks.wiki) and dynamically renders ride information—including park names, ride names, and wait times—onto an LED matrix. The application supports both actual hardware and an emulator for testing purposes.
 
 ## Features
 
 - **API Integration:**  
-  Retrieves Walt Disney World park data and attraction details using HTTP requests.
-- **Live Data Updates:**  
-  Uses a background thread to periodically update live wait times for attractions.
+  Retrieves park data and attraction details for Walt Disney World, Cedar Point, Kings Island, and any other destination supported by the ThemeParks Wiki API. Parks are configured by name in `config.json`.
+- **Real-Time WebSocket Updates:**  
+  When a ThemeParks API key is configured, live wait times are delivered via a persistent WebSocket connection (`wss://ws.themeparks.wiki/v1/live`) for instant updates as attraction statuses change. The app performs an initial REST fetch at startup to populate all data, then hands off to the WebSocket for ongoing updates. If the WebSocket disconnects and reconnects, a REST refresh is automatically triggered to catch any changes missed during the outage.
+- **Polling Fallback:**  
+  Without an API key, the app falls back to polling the REST API every 5 minutes for live wait times.
 - **Dynamic Display Rendering:**  
   Renders park details, character meet and greets (w/ Wait Times) and ride information with dynamic text wrapping and spacing on an LED matrix.
 - **Trip Countdown:**  
-  Displays a countdown to your next Disney visit for added excitement.
+  Displays a countdown to your next Disney visit for added excitement. Supports multiple upcoming trip dates.
 - **Current Weather Updates:**  
   Provides live weather information for each park.
 - **Emulation Mode:**  
@@ -170,6 +172,26 @@ You can configure your LED matrix with the same flags used in the [rpi-rgb-led-m
 --emulated                Force the scoreboard to run in software emulation mode.
 --drop-privileges         Force the matrix driver to drop root privileges after setup. (Default: true)
 ```
+
+### ThemeParks API Key (Recommended)
+
+To enable real-time WebSocket updates, add a ThemeParks API key to `config.json`:
+
+```json
+"themeparks_api_key": "your-api-key-here"
+```
+
+Without this key the app falls back to polling the REST API every 5 minutes. With it, attraction status changes appear on the display within seconds. You can request an API key from the [ThemeParks Wiki](https://api.themeparks.wiki).
+
+### Configuring Parks
+
+By default the app shows all four Walt Disney World theme parks. You can configure any combination of parks from any ThemeParks Wiki destination in `config.json`:
+
+```json
+"parks": ["Magic Kingdom", "EPCOT", "Hollywood Studios", "Animal Kingdom", "Cedar Point"]
+```
+
+Leave the list empty to default to all Walt Disney World parks.
 
 ### Weather (Future Enhancement)
  The weather API we use is from OpenWeatherMaps. OpenWeatherMaps API requires an API key to fetch this data so you will need to take a quick minute to sign up for an account and copy your own API key into your `config.json`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LightningLane-Live-LED is a Python application designed to fetch and display wai
 - **API Integration:**  
   Retrieves park data and attraction details for Walt Disney World, Cedar Point, Kings Island, and any other destination supported by the ThemeParks Wiki API. Parks are configured by name in `config.json`.
 - **Real-Time WebSocket Updates:**  
-  When a ThemeParks API key is configured, live wait times are delivered via a persistent WebSocket connection (`wss://ws.themeparks.wiki/v1/live`) for instant updates as attraction statuses change. The app performs an initial REST fetch at startup to populate all data, then hands off to the WebSocket for ongoing updates. If the WebSocket disconnects and reconnects, a REST refresh is automatically triggered to catch any changes missed during the outage.
+  When a ThemeParks API key is configured (or `websocket_only` is enabled — see [below](#themeparks-api-key-recommended)), live wait times are delivered via a persistent WebSocket connection (`wss://ws.themeparks.wiki/v1/live`) for instant updates as attraction statuses change. The app performs an initial REST fetch at startup to populate all data, then hands off to the WebSocket for ongoing updates. The connection is self-healing: a dead or silently-stalled connection is detected and reconnected automatically (typically within 2 minutes), with a REST refresh triggered afterward to catch any changes missed during the outage.
 - **Polling Fallback:**  
   Without an API key, the app falls back to polling the REST API every 5 minutes for live wait times.
 - **Dynamic Display Rendering:**  
@@ -182,6 +182,24 @@ To enable real-time WebSocket updates, add a ThemeParks API key to `config.json`
 ```
 
 Without this key the app falls back to polling the REST API every 5 minutes. With it, attraction status changes appear on the display within seconds. You can request an API key from the [ThemeParks Wiki](https://api.themeparks.wiki).
+
+If you'd rather not use an API key, you can still enable WebSocket mode by setting `websocket_only` to `true` in `config.json`:
+
+```json
+"websocket_only": true
+```
+
+This connects to the same public WebSocket feed without sending an API key. Leave both `themeparks_api_key` unset (or set to the placeholder value) and `websocket_only: false` to use REST polling only.
+
+#### WebSocket Connection Health
+
+The WebSocket connection is monitored and self-healing:
+- A dead connection (network drop, server-side timeout) is detected within about 2 minutes and reconnected automatically.
+- A connection that stays open but silently stops delivering updates is detected by a background watchdog and force-reconnected, as long as at least one configured park is currently operating.
+- Every reconnect (whether from an error or the watchdog) triggers a REST refresh so the display catches up on anything missed during the outage.
+- Reconnect attempts back off (5s, 10s, 20s, ... up to 60s) if the connection keeps failing quickly, so a persistent outage doesn't hammer the API.
+
+You can watch this behavior in the logs (`logs/app.log`) — look for `WebSocket connected`, `WS heartbeat`, and `WebSocket disconnected; reconnecting in Ns` messages.
 
 ### Configuring Parks
 

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from datetime import datetime, timedelta, timezone
 
 import aiohttp
@@ -11,6 +12,30 @@ from utils.utils import get_eastern
 troublesome_attraction_64x64_ids = ["8d7ccdb1-a22b-4e26-8dc8-65b1938ed5f0","06c599f9-1ddf-4d47-9157-a992acafc96b", "22f48b73-01df-460e-8969-9eb2b4ae836c",  "9211adc9-b296-4667-8e97-b40cf76108e4","64a6915f-a835-4226-ba5c-8389fc4cade3"]
 troublesome_attraction_64x32_ids = ["9211adc9-b296-4667-8e97-b40cf76108e4","64a6915f-a835-4226-ba5c-8389fc4cade3"]
 troublesome_attraction_single_ids = ["1e735ffb-4868-47f1-b2cd-2ac1156cd5f0"]
+
+DISNEY_WORLD_DESTINATION_ID = "e957da41-3552-4cf6-b636-5babc5cbc4e5"
+_UUID_RE = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.IGNORECASE)
+
+
+def resolve_destination_id(name_or_id):
+    """Return a destination UUID. If name_or_id already looks like a UUID, return it as-is.
+    Otherwise fetch the destinations list and match by name (case-insensitive)."""
+    if _UUID_RE.match(name_or_id):
+        return name_or_id
+    try:
+        response = requests.get("https://api.themeparks.wiki/v1/destinations")
+        response.raise_for_status()
+        destinations = response.json().get("destinations", [])
+        name_lower = name_or_id.lower()
+        for dest in destinations:
+            if dest.get("name", "").lower() == name_lower:
+                debug.info(f"Resolved destination '{name_or_id}' → {dest['id']}")
+                return dest["id"]
+        debug.error(f"No destination found matching '{name_or_id}'")
+        return None
+    except requests.RequestException as e:
+        debug.error(f"Failed to fetch destinations list: {e}")
+        return None
 
 
 def get_park_location(park_id):
@@ -53,54 +78,57 @@ def fetch_park_schedule(park_id):
         debug.error(f"Failed to fetch schedule for park ID {park_id}: {e}")
         return []
 
-def fetch_list_of_disney_world_parks():
+WATER_PARK_KEYWORDS = ("Water Park", "Shores")
+
+def fetch_parks_from_destination(destination_id):
     """
-    Fetch and return a list of Walt Disney World parks with their respective IDs
-    and schedule info, excluding water parks. The schedule is filtered to only include
-    events for today and the day before.
+    Fetch parks from any ThemeParks Wiki destination, excluding water parks.
+    Schedule is filtered to today and yesterday only.
     """
-    walt_disney_world_entity_id = "e957da41-3552-4cf6-b636-5babc5cbc4e5"
-    api_url = f"https://api.themeparks.wiki/v1/entity/{walt_disney_world_entity_id}/schedule"
-    debug.info("url: %s", api_url)
-    debug.info("Fetching Disney World schedule data...")
+    api_url = f"https://api.themeparks.wiki/v1/entity/{destination_id}/schedule"
+    debug.info("Fetching parks for destination %s", destination_id)
 
     try:
         response = requests.get(api_url)
         response.raise_for_status()
-        debug.info("Status Code: %s", response.raise_for_status())
-        debug.info("Fetched Walt Disney World schedule data. Response: %s", response.json())
         parks_data = response.json().get("parks", [])
 
-        # Determine today's date and yesterday's date as strings.
         today = datetime.now()
         today_str = today.strftime('%Y-%m-%d')
         yesterday_str = (today - timedelta(days=1)).strftime('%Y-%m-%d')
 
+        is_disney = destination_id == DISNEY_WORLD_DESTINATION_ID
         filtered_parks = []
         for park in parks_data:
-            # debug.log(f"Park Location: {pretty_print_json(park)}")
-            if isinstance(park, dict) and "Water Park" not in park.get("name", ""):
-                schedule = park.get("schedule")
-                # Filter schedule events to include only those from today or yesterday.
-                schedule_filtered = [
-                    event for event in schedule if event.get("date") in (today_str, yesterday_str)
-                ]
-                debug.log(f"Schedule Filter: {schedule_filtered}")
-                filtered_parks.append({
-                    "name": park.get("name", "Unknown"),
-                    "id": park.get("id", "Unknown"),
-                    "schedule": schedule_filtered,
-                    "weather": [],  # Get initial weather data
-                    "location": get_park_location(park.get("id"))
-                })
+            if not isinstance(park, dict):
+                continue
+            park_name = park.get("name", "")
+            if any(kw in park_name for kw in WATER_PARK_KEYWORDS):
+                continue
+            schedule = park.get("schedule") or []
+            schedule_filtered = [
+                event for event in schedule if event.get("date") in (today_str, yesterday_str)
+            ]
+            debug.log(f"Schedule Filter: {schedule_filtered}")
+            filtered_parks.append({
+                "name": clean_park_name(park_name) if is_disney else park_name,
+                "id": park.get("id", "Unknown"),
+                "schedule": schedule_filtered,
+                "weather": [],
+                "location": get_park_location(park.get("id"))
+            })
 
-        debug.info(f"Found {len(filtered_parks)} parks under Walt Disney World after filtering by date.")
-        debug.log(f"Filtered Parks: {filtered_parks}")
+        debug.info(f"Found {len(filtered_parks)} parks for destination {destination_id}.")
         return filtered_parks
 
     except requests.RequestException as e:
-        debug.error(f"Failed to fetch schedule data: {e}")
+        debug.error(f"Failed to fetch parks for destination {destination_id}: {e}")
         return []
+
+
+def fetch_list_of_disney_world_parks():
+    """Fetch Walt Disney World parks. Retained for backward compatibility."""
+    return fetch_parks_from_destination("e957da41-3552-4cf6-b636-5babc5cbc4e5")
 
 
 def fetch_parks_and_attractions(disney_park_list):
@@ -127,7 +155,7 @@ def fetch_parks_and_attractions(disney_park_list):
 
         attractions = []
         for item in park_data.get("children", []):
-            if (item.get("entityType") == "ATTRACTION") or (item.get("entityType") == "SHOW" and ("Meet" in item.get("name", "") or "Star Wars Launch Bay:" in item.get("name", ""))): # and (item.get("id") in troublesome_attraction_64x64_ids or item.get("id") in troublesome_attraction_64x32_ids):
+            if item.get("entityType") in ("ATTRACTION", "SHOW"):
                 attraction = {
                     "id": item.get("id"),
                     "name": get_attraction_name(item),
@@ -142,7 +170,7 @@ def fetch_parks_and_attractions(disney_park_list):
         debug.info(f"{len(attractions)} were found in {park_name}")
         park_obj = {
             "id": park_id,
-            "name": park_name.replace("Theme", " ").replace("Park", " ").replace("Disney's", "").strip(),
+            "name": park_name,
             "attractions": attractions,
             "specialTicketedEvent": is_special_event(schedule),
             "closingTime": operating_event.get("closingTime", ""),
@@ -153,6 +181,10 @@ def fetch_parks_and_attractions(disney_park_list):
         }
         parks.append(park_obj)
     return parks
+
+
+def clean_park_name(raw_name):
+    return raw_name.replace("Theme", " ").replace("Park", " ").replace("Disney's", "").strip()
 
 
 def get_attraction_name(item):
@@ -210,9 +242,20 @@ async def fetch_live_data_for_attraction(session, attraction):
                     if live_data_entry.get("status") == "DOWN" and live_data_entry.get("entityType") == "ATTRACTION":
                         attraction["waitTime"] = f"Down {get_down_time(live_data_entry.get('lastUpdated'))}"
                     if live_data_entry.get("status") not in ["CLOSED", "REFURBISHMENT","DOWN"]:
-                        attraction["waitTime"] = live_data_entry.get("queue", {}) \
-                            .get("STANDBY", {}) \
-                            .get("waitTime", None)
+                        queue = live_data_entry.get("queue", {})
+                        standby_wait = queue.get("STANDBY", {}).get("waitTime", None)
+                        if standby_wait is not None:
+                            attraction["waitTime"] = standby_wait
+                        else:
+                            bg = queue.get("BOARDING_GROUP", {})
+                            start = bg.get("currentGroupStart")
+                            end = bg.get("currentGroupEnd")
+                            if start is not None and end is not None:
+                                attraction["waitTime"] = f"Groups {start}-{end}"
+                            elif start is not None:
+                                attraction["waitTime"] = f"Group {start}+"
+                            else:
+                                attraction["waitTime"] = None
             else:
                 debug.error(f"Failed to fetch live data for {attraction['name']}, Status Code: {response.status}")
     except Exception as e:

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -381,6 +381,61 @@ def handle_park_schedule_update(is_park_open, park):
         park["closingTime"] = operating_event.get("closingTime", "")
         park["openingTime"] = operating_event.get("openingTime", "")
 
+        refresh_park_attractions(park)
+
+
+def refresh_park_attractions(park):
+    """
+    Re-fetch the children endpoint when a park opens and reconcile the attraction list:
+    update names, add new attractions, remove ones no longer returned.
+    """
+    park_id = park.get("id")
+    park_name = park.get("name", "Unknown")
+    api_url = f"https://api.themeparks.wiki/v1/entity/{park_id}/children"
+
+    try:
+        response = requests.get(api_url)
+        response.raise_for_status()
+        children = response.json().get("children", [])
+    except requests.RequestException as e:
+        debug.error(f"Failed to refresh attractions for {park_name}: {e}")
+        return
+
+    fresh = {
+        item["id"]: item
+        for item in children
+        if item.get("entityType") in ("ATTRACTION", "SHOW")
+    }
+
+    existing = park.get("attractions", [])
+
+    for attr in existing:
+        if attr["id"] in fresh:
+            attr["name"] = get_attraction_name(fresh[attr["id"]])
+
+    existing_ids = {a["id"] for a in existing}
+    for attr_id, item in fresh.items():
+        if attr_id not in existing_ids:
+            existing.append({
+                "id": attr_id,
+                "name": get_attraction_name(item),
+                "entityType": item.get("entityType"),
+                "parkId": park_id,
+                "waitTime": "",
+                "status": "",
+                "lastUpdatedTs": "",
+                "down_since": ""
+            })
+            debug.info(f"New attraction added to {park_name}: {get_attraction_name(item)}")
+
+    before = len(existing)
+    park["attractions"] = [a for a in existing if a["id"] in fresh]
+    removed = before - len(park["attractions"])
+    if removed:
+        debug.info(f"Removed {removed} attraction(s) from {park_name} no longer in roster")
+
+    debug.info(f"Refreshed {len(park['attractions'])} attractions for {park_name}")
+
 
 if __name__ == "__main__":
     # Fetch parks with filtered schedule (today and yesterday)

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -261,14 +261,15 @@ def determine_llmp_price(operating_event):
     return lightning_lane_multi_pass_price
 
 
-def get_down_time(last_updated_date, date_format='%Y-%m-%dT%H:%M:%SZ'):
+def get_down_time(last_updated_date):
     try:
-        target_date = datetime.strptime(last_updated_date, date_format).replace(tzinfo=timezone.utc)
+        normalized = last_updated_date.replace("Z", "+00:00")
+        target_date = datetime.fromisoformat(normalized)
         current_time = datetime.now(timezone.utc)
         time_diff = current_time - target_date
         minutes = time_diff.total_seconds() / 60
         return round(minutes)
-    except ValueError:
+    except (ValueError, AttributeError):
         debug.error(f"Invalid date format: {last_updated_date}")
         return None
 

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -74,7 +74,7 @@ def fetch_park_schedule(park_id):
             event for event in schedule_data if event.get("date") in (today_str, yesterday_str)
         ]
 
-        debug.info(f"Schedule Data for park ID {park_id}: {schedule_data}")
+        debug.log(f"Schedule Data for park ID {park_id}: {schedule_data}")
         return schedule_filtered
     except requests.RequestException as e:
         debug.error(f"Failed to fetch schedule for park ID {park_id}: {e}")
@@ -115,6 +115,7 @@ def fetch_parks_from_destination(destination_id):
             filtered_parks.append({
                 "name": clean_park_name(park_name) if is_disney else park_name,
                 "id": park.get("id", "Unknown"),
+                "destination_id": destination_id,
                 "schedule": schedule_filtered,
                 "weather": [],
                 "location": get_park_location(park.get("id"))
@@ -220,6 +221,7 @@ def fetch_parks_and_attractions(disney_park_list):
         park_obj = {
             "id": park_id,
             "name": park_name,
+            "destination_id": park_info.get("destination_id"),
             "attractions": attractions,
             "specialTicketedEvent": is_special_event(schedule),
             "closingTime": operating_event.get("closingTime", ""),
@@ -278,7 +280,7 @@ async def fetch_live_data_for_attraction(session, attraction):
     current_data = attraction.copy()
 
     api_url = f"https://api.themeparks.wiki/v1/entity/{attraction['id']}/live"
-    debug.info(f"Fetching live data for attraction: {attraction['name']} (ID: {attraction['id']})")
+    debug.log(f"Fetching live data for attraction: {attraction['name']} (ID: {attraction['id']})")
     try:
         async with session.get(api_url) as response:
             if response.status == 200:
@@ -311,9 +313,9 @@ async def fetch_live_data_for_attraction(session, attraction):
         debug.error(f"Error occurred while fetching live data for {attraction['name']}: {e}")
 
     if current_data != attraction:
-        debug.info(f"There is new data for {attraction['name']} | Wait time: {current_data['waitTime']}(Existing) vs {attraction['waitTime']}(New) | Status: {current_data['status']}(Existing) vs {attraction['status']}(New) | Last updated: {get_eastern(current_data['lastUpdatedTs'])}(Existing) vs {get_eastern(attraction['lastUpdatedTs'])}(New)")
+        debug.log(f"There is new data for {attraction['name']} | Wait time: {current_data['waitTime']}(Existing) vs {attraction['waitTime']}(New) | Status: {current_data['status']}(Existing) vs {attraction['status']}(New) | Last updated: {get_eastern(current_data['lastUpdatedTs'])}(Existing) vs {get_eastern(attraction['lastUpdatedTs'])}(New)")
     else:
-        debug.info(f"No new data for {attraction['name']}")
+        debug.log(f"No new data for {attraction['name']}")
     return attraction
 
 async def fetch_live_data(attractions):
@@ -325,7 +327,7 @@ async def fetch_live_data(attractions):
     async with aiohttp.ClientSession(connector=connector) as session:
         tasks = [fetch_live_data_for_attraction(session, attraction) for attraction in attractions]
         results = await asyncio.gather(*tasks)
-    debug.info(f"Total live data fetched: {len(results)}")
+    debug.log(f"Total live data fetched: {len(results)}")
     return results
 
 def park_has_operating_attraction(park):
@@ -334,7 +336,7 @@ def park_has_operating_attraction(park):
     Returns True if at least one attraction is operating (i.e. its 'status' is not "CLOSED" or "REFURBISHMENT")
     and its 'waitTime' is not None or empty, otherwise returns False.
     """
-    debug.info(f"Searching for open attraction's in {park['name']}")
+    debug.log(f"Searching for open attraction's in {park['name']}")
     for attraction in park.get("attractions", []):
         wait_time = attraction.get("waitTime")
         status = attraction.get("status")

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -333,21 +333,34 @@ async def fetch_live_data(attractions):
 
 def park_has_operating_attraction(park):
     """
-    Check if any attraction in the park is operating and has a wait time.
-    Returns True if at least one attraction is operating (i.e. its 'status' is not "CLOSED" or "REFURBISHMENT")
-    and its 'waitTime' is not None or empty, otherwise returns False.
+    Returns True only if the park is within its scheduled hours AND has at least
+    one OPERATING attraction with a non-empty wait time.
+    A park whose entire live feed has gone stale (all DOWN, no OPERATING) returns False.
+    A park past its closing time returns False regardless of API status.
     """
-    debug.log(f"Searching for open attraction's in {park['name']}")
+    closing_time_str = park.get("closingTime")
+    if closing_time_str:
+        try:
+            closing_dt = datetime.fromisoformat(closing_time_str)
+            now = datetime.now(closing_dt.tzinfo)
+            if now > closing_dt:
+                debug.info(f"{park['name']} is past closing time ({closing_time_str}), marking non-operating.")
+                return False
+        except (ValueError, TypeError):
+            pass
+
+    debug.log(f"Searching for open attractions in {park['name']}")
     for attraction in park.get("attractions", []):
         wait_time = attraction.get("waitTime")
         status = attraction.get("status")
         debug.log(
             f"Attraction: {attraction['name']} (Park: {park['name']}) | "
-            f"Wait Time: {attraction['waitTime']} | Status: {attraction['status']}"
+            f"Wait Time: {wait_time} | Status: {status}"
         )
-        if wait_time not in [None, ''] and status.upper() == "OPERATING":
+        if status and status.upper() == "OPERATING" and wait_time not in (None, ''):
             debug.info(f"Found open attraction in {park['name']}: {attraction['name']}")
             return True
+    debug.info(f"{park['name']}: no OPERATING attractions found, marking non-operating.")
     return False
 
 

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -1,8 +1,10 @@
 import asyncio
 import re
+import ssl
 from datetime import datetime, timedelta, timezone
 
 import aiohttp
+import certifi
 import requests
 
 from api.weather import fetch_weather_data
@@ -128,7 +130,51 @@ def fetch_parks_from_destination(destination_id):
 
 def fetch_list_of_disney_world_parks():
     """Fetch Walt Disney World parks. Retained for backward compatibility."""
-    return fetch_parks_from_destination("e957da41-3552-4cf6-b636-5babc5cbc4e5")
+    return fetch_parks_from_destination(DISNEY_WORLD_DESTINATION_ID)
+
+
+def resolve_parks_from_config(park_names):
+    """
+    Given a list of park names from config, fetch only the destinations that contain
+    those parks and return the matching park dicts. Matches against both raw API names
+    and Disney-cleaned names, case-insensitively. If park_names is empty, returns all
+    Walt Disney World parks.
+    """
+    if not park_names:
+        return fetch_list_of_disney_world_parks()
+
+    try:
+        response = requests.get("https://api.themeparks.wiki/v1/destinations")
+        response.raise_for_status()
+        destinations = response.json().get("destinations", [])
+    except requests.RequestException as e:
+        debug.error(f"Failed to fetch destinations list: {e}")
+        return []
+
+    names_lower = {n.lower() for n in park_names}
+
+    # Map destination_id -> set of matched park IDs
+    dest_park_ids = {}
+    for dest in destinations:
+        dest_id = dest["id"]
+        is_disney = dest_id == DISNEY_WORLD_DESTINATION_ID
+        for park in dest.get("parks", []):
+            raw = park.get("name", "")
+            cleaned = clean_park_name(raw) if is_disney else raw
+            if raw.lower() in names_lower or cleaned.lower() in names_lower:
+                dest_park_ids.setdefault(dest_id, set()).add(park["id"])
+
+    if not dest_park_ids:
+        debug.error(f"No destinations found for parks: {park_names}")
+        return []
+
+    result = []
+    for dest_id, park_ids in dest_park_ids.items():
+        parks = fetch_parks_from_destination(dest_id)
+        result.extend(p for p in parks if p["id"] in park_ids)
+
+    debug.info(f"Resolved {len(result)} park(s) from config: {[p['name'] for p in result]}")
+    return result
 
 
 def fetch_parks_and_attractions(disney_park_list):
@@ -271,7 +317,9 @@ async def fetch_live_data(attractions):
     """
     Fetch live data for all attractions concurrently.
     """
-    async with aiohttp.ClientSession() as session:
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    connector = aiohttp.TCPConnector(ssl=ssl_ctx)
+    async with aiohttp.ClientSession(connector=connector) as session:
         tasks = [fetch_live_data_for_attraction(session, attraction) for attraction in attractions]
         results = await asyncio.gather(*tasks)
     debug.info(f"Total live data fetched: {len(results)}")

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 import ssl
 from datetime import datetime, timedelta, timezone
@@ -9,7 +8,6 @@ import requests
 
 from api.weather import fetch_weather_data
 from utils import debug
-from utils.utils import get_eastern
 
 troublesome_attraction_64x64_ids = ["8d7ccdb1-a22b-4e26-8dc8-65b1938ed5f0","06c599f9-1ddf-4d47-9157-a992acafc96b", "22f48b73-01df-460e-8969-9eb2b4ae836c",  "9211adc9-b296-4667-8e97-b40cf76108e4","64a6915f-a835-4226-ba5c-8389fc4cade3"]
 troublesome_attraction_64x32_ids = ["9211adc9-b296-4667-8e97-b40cf76108e4","64a6915f-a835-4226-ba5c-8389fc4cade3"]
@@ -273,63 +271,72 @@ def get_down_time(last_updated_date):
         debug.error(f"Invalid date format: {last_updated_date}")
         return None
 
-async def fetch_live_data_for_attraction(session, attraction):
+def parse_queue_wait(queue):
     """
-    Fetch live data for a single attraction.
-    If the status is not "CLOSED" or "REFURBISHMENT", update the waitTime.
+    Extract a display wait value from a liveData queue block: STANDBY minutes,
+    a boarding group range, or None when neither is available.
     """
-    current_data = attraction.copy()
+    standby_wait = (queue.get("STANDBY") or {}).get("waitTime")
+    if standby_wait is not None:
+        return standby_wait
+    bg = queue.get("BOARDING_GROUP") or {}
+    start = bg.get("currentGroupStart")
+    end = bg.get("currentGroupEnd")
+    if start is not None and end is not None:
+        return f"Groups {start}-{end}"
+    if start is not None:
+        return f"Group {start}+"
+    return None
 
-    api_url = f"https://api.themeparks.wiki/v1/entity/{attraction['id']}/live"
-    debug.log(f"Fetching live data for attraction: {attraction['name']} (ID: {attraction['id']})")
-    try:
-        async with session.get(api_url) as response:
-            if response.status == 200:
-                data = await response.json()
-                live_data_info = data.get('liveData', [])
-                if live_data_info:
-                    live_data_entry = live_data_info[0]  # Use the first liveData entry
-                    attraction["lastUpdatedTs"] = live_data_entry.get("lastUpdated", None)
-                    attraction["status"] = live_data_entry.get("status", None)
-                    if live_data_entry.get("status") == "DOWN" and live_data_entry.get("entityType") == "ATTRACTION":
-                        attraction["waitTime"] = f"Down {get_down_time(live_data_entry.get('lastUpdated'))}"
-                    if live_data_entry.get("status") not in ["CLOSED", "REFURBISHMENT","DOWN"]:
-                        queue = live_data_entry.get("queue", {})
-                        standby_wait = queue.get("STANDBY", {}).get("waitTime", None)
-                        if standby_wait is not None:
-                            attraction["waitTime"] = standby_wait
-                        else:
-                            bg = queue.get("BOARDING_GROUP", {})
-                            start = bg.get("currentGroupStart")
-                            end = bg.get("currentGroupEnd")
-                            if start is not None and end is not None:
-                                attraction["waitTime"] = f"Groups {start}-{end}"
-                            elif start is not None:
-                                attraction["waitTime"] = f"Group {start}+"
-                            else:
-                                attraction["waitTime"] = None
-            else:
-                debug.error(f"Failed to fetch live data for {attraction['name']}, Status Code: {response.status}")
-    except Exception as e:
-        debug.error(f"Error occurred while fetching live data for {attraction['name']}: {e}")
 
-    if current_data != attraction:
-        debug.log(f"There is new data for {attraction['name']} | Wait time: {current_data['waitTime']}(Existing) vs {attraction['waitTime']}(New) | Status: {current_data['status']}(Existing) vs {attraction['status']}(New) | Last updated: {get_eastern(current_data['lastUpdatedTs'])}(Existing) vs {get_eastern(attraction['lastUpdatedTs'])}(New)")
-    else:
-        debug.log(f"No new data for {attraction['name']}")
-    return attraction
+def build_live_updates(live_entries):
+    """
+    Convert raw liveData entries into the minimal update dicts merge_live_data
+    consumes. CLOSED/REFURBISHMENT entries (and DOWN shows) omit waitTime so the
+    last known value is preserved.
+    """
+    updates = []
+    for entry in live_entries:
+        if entry.get("entityType") not in ("ATTRACTION", "SHOW"):
+            continue
+        status = entry.get("status")
+        update = {
+            "id": entry.get("id"),
+            "status": status,
+            "lastUpdatedTs": entry.get("lastUpdated"),
+        }
+        if status == "DOWN":
+            if entry.get("entityType") == "ATTRACTION":
+                update["waitTime"] = f"Down {get_down_time(entry.get('lastUpdated'))}"
+        elif status not in ("CLOSED", "REFURBISHMENT"):
+            update["waitTime"] = parse_queue_wait(entry.get("queue") or {})
+        updates.append(update)
+    return updates
 
-async def fetch_live_data(attractions):
+
+async def fetch_park_live_data(park):
     """
-    Fetch live data for all attractions concurrently.
+    Fetch live data for all of a park's attractions with a single request to the
+    park-level live endpoint. Returns a list of update dicts for merge_live_data,
+    or None if the fetch failed (caller keeps existing data and retries later).
     """
+    api_url = f"https://api.themeparks.wiki/v1/entity/{park['id']}/live"
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
     connector = aiohttp.TCPConnector(ssl=ssl_ctx)
-    async with aiohttp.ClientSession(connector=connector) as session:
-        tasks = [fetch_live_data_for_attraction(session, attraction) for attraction in attractions]
-        results = await asyncio.gather(*tasks)
-    debug.log(f"Total live data fetched: {len(results)}")
-    return results
+    try:
+        async with aiohttp.ClientSession(connector=connector) as session:
+            async with session.get(api_url) as response:
+                if response.status != 200:
+                    debug.error(f"Failed to fetch live data for {park.get('name')}, Status Code: {response.status}")
+                    return None
+                data = await response.json()
+    except Exception as e:
+        debug.error(f"Error occurred while fetching live data for {park.get('name')}: {e}")
+        return None
+
+    updates = build_live_updates(data.get("liveData", []))
+    debug.log(f"Live data fetched for {park.get('name')}: {len(updates)} entries")
+    return updates
 
 def park_has_operating_attraction(park):
     """

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -173,6 +173,9 @@ def resolve_parks_from_config(park_names):
         parks = fetch_parks_from_destination(dest_id)
         result.extend(p for p in parks if p["id"] in park_ids)
 
+    name_to_index = {n.lower(): i for i, n in enumerate(park_names)}
+    result.sort(key=lambda p: name_to_index.get(p["name"].lower(), len(park_names)))
+
     debug.info(f"Resolved {len(result)} park(s) from config: {[p['name'] for p in result]}")
     return result
 

--- a/api/disney_api.py
+++ b/api/disney_api.py
@@ -364,40 +364,46 @@ def park_has_operating_attraction(park):
     return False
 
 
-def update_parks_operating_status(parks):
+def update_parks_operating_status(parks, fetch_schedules=True):
     """
     Updates each park object in the list with a new key 'operating' that is
     True if the park has at least one operating attraction with a valid
     wait time, otherwise False.
+
+    When a park transitions from closed to open it needs a schedule fetch
+    (blocking HTTP). With fetch_schedules=False that work is only flagged via
+    'schedule_refresh_needed' — safe to call from the WS event loop — and a
+    later call with fetch_schedules=True (the REST thread) performs it.
     """
 
     for park in parks:
         is_park_open = park_has_operating_attraction(park)  # Check if any attractions are operating
-        handle_park_schedule_update(is_park_open, park)
+        if not park.get("operating") and is_park_open:
+            park["schedule_refresh_needed"] = True
         # Update the operating status
         park["operating"] = is_park_open
+
+        if fetch_schedules and park.get("schedule_refresh_needed"):
+            handle_park_schedule_update(park)
+            park["schedule_refresh_needed"] = False
 
     return parks
 
 
-def handle_park_schedule_update(is_park_open, park):
-    # Check if the park was previously closed
-    previously_operating = park.get("operating")
-    # If the park was previously closed but is now open
-    if not previously_operating and is_park_open:
-        debug.info(f"{park.get('name')} is now operating. Fetching schedule...")
-        schedule = fetch_park_schedule(park.get("id"))
-        park["schedule"] = schedule
-        debug.info(f"Updated schedule for {park.get('name')}")
+def handle_park_schedule_update(park):
+    debug.info(f"{park.get('name')} is now operating. Fetching schedule...")
+    schedule = fetch_park_schedule(park.get("id"))
+    park["schedule"] = schedule
+    debug.info(f"Updated schedule for {park.get('name')}")
 
-        # Update park schedule details
-        operating_event = next((event for event in schedule if event.get("type") == "OPERATING"), {})
-        park["llmpPrice"] = determine_llmp_price(operating_event)
-        park["specialTicketedEvent"] = is_special_event(schedule)
-        park["closingTime"] = operating_event.get("closingTime", "")
-        park["openingTime"] = operating_event.get("openingTime", "")
+    # Update park schedule details
+    operating_event = next((event for event in schedule if event.get("type") == "OPERATING"), {})
+    park["llmpPrice"] = determine_llmp_price(operating_event)
+    park["specialTicketedEvent"] = is_special_event(schedule)
+    park["closingTime"] = operating_event.get("closingTime", "")
+    park["openingTime"] = operating_event.get("openingTime", "")
 
-        refresh_park_attractions(park)
+    refresh_park_attractions(park)
 
 
 def refresh_park_attractions(park):

--- a/config.json-example
+++ b/config.json-example
@@ -11,5 +11,6 @@
   "weather": {
     "apikey": "<API_KEY_HERE>"
   },
+  "websocket_only": false,
   "debug": false
 }

--- a/config.json-example
+++ b/config.json-example
@@ -1,5 +1,4 @@
 {
-  "destinations": ["Walt Disney World Resort"],
   "parks": ["Magic Kingdom", "EPCOT", "Hollywood Studios", "Animal Kingdom"],
   "trip_countdown": {
     "enabled": true,

--- a/config.json-example
+++ b/config.json-example
@@ -1,5 +1,6 @@
 {
   "parks": ["Magic Kingdom", "EPCOT", "Hollywood Studios", "Animal Kingdom"],
+  "themeparks_api_key": "89e4add6-30cd-4960-83a7-eb7882a1649a",
   "trip_countdown": {
     "enabled": true,
     "trip_dates": [

--- a/config.json-example
+++ b/config.json-example
@@ -1,4 +1,6 @@
 {
+  "destinations": ["Walt Disney World Resort"],
+  "parks": ["Magic Kingdom", "EPCOT", "Hollywood Studios", "Animal Kingdom"],
   "trip_countdown": {
     "enabled": true,
     "trip_dates": [

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+import os
+import tempfile
+
+# Redirect utils.debug's log file into a throwaway temp directory before any
+# test module can import utils.debug (that import wires up a RotatingFileHandler
+# pointed at the real logs/app.log). Without this, running pytest alongside a
+# live app instance interleaves test fixture data into the real log and can
+# even trip live logic that reacts to log-derived state (e.g. the WebSocket
+# watchdog's message counter).
+os.environ.setdefault('LLL_LOG_DIR', tempfile.mkdtemp(prefix='lll-test-logs-'))

--- a/disney.py
+++ b/disney.py
@@ -18,6 +18,7 @@ from utils.utils import args, led_matrix_options
 from api.disney_api import fetch_list_of_disney_world_parks, resolve_parks_from_config
 from display.attractions.attraction_info import render_attraction_info
 from updater.data_updater import live_data_updater
+from updater.websocket_updater import websocket_live_updater
 from display.countdown.countdown import render_countdown_to_disney
 
 from utils import debug
@@ -69,12 +70,27 @@ def main():
         debug.error("No parks found. Exiting.")
         return
 
+    api_key = config.get("themeparks_api_key")
+    use_websocket = bool(api_key and not api_key.startswith("<"))
+
     update_thread = threading.Thread(
         target=live_data_updater,
         args=(disney_park_list, update_interval, parks_data),
+        kwargs={"use_websocket": use_websocket},
         daemon=True
     )
     update_thread.start()
+
+    if use_websocket:
+        ws_thread = threading.Thread(
+            target=websocket_live_updater,
+            args=(api_key, parks_data),
+            daemon=True
+        )
+        ws_thread.start()
+        debug.info("WebSocket live updater started — REST live data polling disabled.")
+    else:
+        debug.info("No ThemeParks API key configured; using polling only.")
 
     # Log configured trip dates at startup
     configured_dates = [d.isoformat() for d in parse_trip_dates(config)]
@@ -212,11 +228,12 @@ def initialize_park_information_screen(matrix, park):
 
 def loop_through_attractions(matrix, park):
     for attraction_info in park.get("attractions", []):
-        matrix.Clear()
-        debug.info(
-            f"Displaying ride: {attraction_info['name']} (Park: {park['name']}) | "f"Wait Time: {attraction_info['waitTime']} min | Status: {attraction_info['status']}")
         if (attraction_info.get("status") not in ["CLOSED", "REFURBISHMENT"]
-            and attraction_info.get("waitTime") not in [None, '']):
+                and attraction_info.get("waitTime") not in [None, '']):
+            matrix.Clear()
+            debug.info(
+                f"Displaying ride: {attraction_info['name']} (Park: {park['name']}) | "
+                f"Wait Time: {attraction_info['waitTime']} min | Status: {attraction_info['status']}")
             render_attraction_info(matrix, attraction_info)
             time.sleep(8)
 

--- a/disney.py
+++ b/disney.py
@@ -71,7 +71,8 @@ def main():
         return
 
     api_key = config.get("themeparks_api_key")
-    use_websocket = bool(api_key and not api_key.startswith("<"))
+    websocket_only = config.get("websocket_only", False)
+    use_websocket = bool(api_key and not api_key.startswith("<")) or websocket_only
 
     update_thread = threading.Thread(
         target=live_data_updater,

--- a/disney.py
+++ b/disney.py
@@ -15,7 +15,7 @@ from display.park.park_details import render_park_information_screen
 from display.display import initialize_fonts
 from display.startup import render_mickey_logo
 from utils.utils import args, led_matrix_options
-from api.disney_api import fetch_list_of_disney_world_parks
+from api.disney_api import fetch_list_of_disney_world_parks, fetch_parks_from_destination, resolve_destination_id
 from display.attractions.attraction_info import render_attraction_info
 from updater.data_updater import live_data_updater
 from display.countdown.countdown import render_countdown_to_disney
@@ -63,10 +63,25 @@ def main():
     matrix = RGBMatrix(options=matrixOptions)
     initialize_fonts(matrix.height)
 
-    disney_park_list = fetch_list_of_disney_world_parks()
+    destination_entries = config.get('destinations', ["Walt Disney World Resort"])
+    disney_park_list = []
+    for entry in destination_entries:
+        dest_id = resolve_destination_id(entry)
+        if dest_id:
+            disney_park_list.extend(fetch_parks_from_destination(dest_id))
+        else:
+            debug.error(f"Could not resolve destination: {entry}")
     if not disney_park_list:
-        debug.error("No Disney parks found. Exiting.")
+        debug.error("No parks found. Exiting.")
         return
+
+    park_filter = config.get('parks')
+    if park_filter:
+        disney_park_list = [p for p in disney_park_list if p['name'] in park_filter]
+        debug.info(f"Park filter active: {park_filter}")
+        if not disney_park_list:
+            debug.error("No parks matched the configured filter. Exiting.")
+            return
 
     update_thread = threading.Thread(
         target=live_data_updater,
@@ -215,7 +230,7 @@ def loop_through_attractions(matrix, park):
         debug.info(
             f"Displaying ride: {attraction_info['name']} (Park: {park['name']}) | "f"Wait Time: {attraction_info['waitTime']} min | Status: {attraction_info['status']}")
         if (attraction_info.get("status") not in ["CLOSED", "REFURBISHMENT"]
-            and attraction_info.get("waitTime") is not None):
+            and attraction_info.get("waitTime") not in [None, '']):
             render_attraction_info(matrix, attraction_info)
             time.sleep(8)
 

--- a/disney.py
+++ b/disney.py
@@ -15,7 +15,7 @@ from display.park.park_details import render_park_information_screen
 from display.display import initialize_fonts
 from display.startup import render_mickey_logo
 from utils.utils import args, led_matrix_options
-from api.disney_api import fetch_list_of_disney_world_parks, fetch_parks_from_destination, resolve_destination_id
+from api.disney_api import fetch_list_of_disney_world_parks, resolve_parks_from_config
 from display.attractions.attraction_info import render_attraction_info
 from updater.data_updater import live_data_updater
 from display.countdown.countdown import render_countdown_to_disney
@@ -63,25 +63,11 @@ def main():
     matrix = RGBMatrix(options=matrixOptions)
     initialize_fonts(matrix.height)
 
-    destination_entries = config.get('destinations', ["Walt Disney World Resort"])
-    disney_park_list = []
-    for entry in destination_entries:
-        dest_id = resolve_destination_id(entry)
-        if dest_id:
-            disney_park_list.extend(fetch_parks_from_destination(dest_id))
-        else:
-            debug.error(f"Could not resolve destination: {entry}")
+    park_names = config.get('parks', [])
+    disney_park_list = resolve_parks_from_config(park_names)
     if not disney_park_list:
         debug.error("No parks found. Exiting.")
         return
-
-    park_filter = config.get('parks')
-    if park_filter:
-        disney_park_list = [p for p in disney_park_list if p['name'] in park_filter]
-        debug.info(f"Park filter active: {park_filter}")
-        if not disney_park_list:
-            debug.error("No parks matched the configured filter. Exiting.")
-            return
 
     update_thread = threading.Thread(
         target=live_data_updater,

--- a/display/attractions/attraction_info.py
+++ b/display/attractions/attraction_info.py
@@ -3,6 +3,12 @@ from driver import graphics
 from utils import debug
 
 
+def _format_wait_time(raw_wait):
+    if isinstance(raw_wait, str) and raw_wait.startswith("Group"):
+        return raw_wait
+    return f"{raw_wait} Mins"
+
+
 def render_attraction_info(matrix, ride_info):
     """
     Renders ride name at the top and wait time at the bottom in a single draw call.
@@ -12,7 +18,7 @@ def render_attraction_info(matrix, ride_info):
     """
     debug.log(f"Rendering ride info: {ride_info}")
     ride_name = ride_info["name"]
-    wait_time = f"{ride_info['waitTime']} Mins"
+    wait_time = _format_wait_time(ride_info["waitTime"])
 
 
     # waittime_font = loaded_fonts["waittime"]

--- a/display/castle.py
+++ b/display/castle.py
@@ -1,0 +1,139 @@
+"""Castle outline based on the provided reference image."""
+
+from driver import graphics
+
+
+def _draw_line(matrix, x0, y0, x1, y1, color):
+    graphics.DrawLine(matrix, x0, y0, x1, y1, color)
+
+
+def _draw_rect_outline(matrix, x0, y0, x1, y1, color):
+    if x0 > x1 or y0 > y1:
+        return
+    x0 = max(0, x0)
+    x1 = min(matrix.width - 1, x1)
+    y0 = max(0, y0)
+    y1 = min(matrix.height - 1, y1)
+    if x0 > x1 or y0 > y1:
+        return
+    _draw_line(matrix, x0, y0, x1, y0, color)
+    _draw_line(matrix, x0, y1, x1, y1, color)
+    _draw_line(matrix, x0, y0, x0, y1, color)
+    _draw_line(matrix, x1, y0, x1, y1, color)
+
+
+def _draw_triangle_outline(matrix, cx, y_top, width, height, color):
+    if width <= 0 or height <= 0:
+        return
+    half_base = width // 2
+    left = cx - half_base
+    right = cx + half_base
+    base_y = y_top + height
+    _draw_line(matrix, cx, y_top, left, base_y, color)
+    _draw_line(matrix, cx, y_top, right, base_y, color)
+    _draw_line(matrix, left, base_y, right, base_y, color)
+
+
+def _draw_tower_outline(matrix, cx, top_y, bottom_y, width, roof_height, color, roof_width=None):
+    if roof_width is None:
+        roof_width = width
+    left = cx - width // 2
+    right = cx + width // 2
+    _draw_rect_outline(matrix, left, top_y, right, bottom_y, color)
+    _draw_triangle_outline(matrix, cx, top_y - roof_height, roof_width, roof_height, color)
+
+
+def render_castle(matrix):
+    matrix.Clear()
+
+    white = graphics.Color(245, 245, 245)
+
+    w = matrix.width
+    h = matrix.height
+    if w < 10 or h < 10:
+        return
+
+    # Castle silhouette bounding box (start at bottom of board)
+    castle_w = int(w * 0.88)
+    castle_h = int(h * 0.90)
+    x0 = (w - castle_w) // 2
+    y0 = h - castle_h
+
+    base_bottom = y0 + castle_h - 1
+    base_top = y0 + int(castle_h * 0.64)
+    mid_top = y0 + int(castle_h * 0.45)
+    keep_top = y0 + int(castle_h * 0.26)
+
+    base_left = x0 + int(castle_w * 0.05)
+    base_right = x0 + int(castle_w * 0.95)
+
+    # Base wall
+    _draw_rect_outline(matrix, base_left, base_top, base_right, base_bottom, white)
+
+    # Mid wall
+    mid_left = x0 + int(castle_w * 0.22)
+    mid_right = x0 + int(castle_w * 0.78)
+    _draw_rect_outline(matrix, mid_left, mid_top, mid_right, base_top - 1, white)
+
+    # Upper keep
+    keep_left = x0 + int(castle_w * 0.38)
+    keep_right = x0 + int(castle_w * 0.62)
+    _draw_rect_outline(matrix, keep_left, keep_top, keep_right, mid_top - 1, white)
+
+    center_x = x0 + castle_w // 2
+
+    # Central spire
+    spire_h = int(castle_h * 0.20)
+    spire_w = int(castle_w * 0.18)
+    spire_top = max(0, keep_top - spire_h)
+    _draw_triangle_outline(matrix, center_x, spire_top, spire_w, spire_h, white)
+
+    # Inner towers
+    inner_offset = int(castle_w * 0.20)
+    inner_w = int(castle_w * 0.12)
+    inner_top = y0 + int(castle_h * 0.30)
+    inner_roof_h = int(castle_h * 0.12)
+    inner_roof_w = int(castle_w * 0.16)
+    for sign in (-1, 1):
+        cx = center_x + sign * inner_offset
+        _draw_tower_outline(matrix, cx, inner_top, mid_top, inner_w, inner_roof_h, white, inner_roof_w)
+
+    # Side main towers
+    side_offset = int(castle_w * 0.32)
+    side_w = int(castle_w * 0.16)
+    side_top = y0 + int(castle_h * 0.40)
+    side_roof_h = int(castle_h * 0.14)
+    side_roof_w = int(castle_w * 0.20)
+    for sign in (-1, 1):
+        cx = center_x + sign * side_offset
+        _draw_tower_outline(matrix, cx, side_top, base_top, side_w, side_roof_h, white, side_roof_w)
+
+    # Outer corner turrets
+    corner_offset = int(castle_w * 0.43)
+    corner_w = int(castle_w * 0.10)
+    corner_top = y0 + int(castle_h * 0.48)
+    corner_roof_h = int(castle_h * 0.10)
+    corner_roof_w = int(castle_w * 0.14)
+    for sign in (-1, 1):
+        cx = center_x + sign * corner_offset
+        _draw_tower_outline(matrix, cx, corner_top, base_top, corner_w, corner_roof_h, white, corner_roof_w)
+
+    # Crenellations on the base wall (outline blocks)
+    crenel_h = max(1, int(castle_h * 0.03))
+    crenel_w = max(1, int(castle_w * 0.05))
+    crenel_gap = max(1, int(castle_w * 0.03))
+    x = base_left + crenel_gap
+    y_crenel_top = base_top - crenel_h
+    while x + crenel_w < base_right - crenel_gap:
+        _draw_rect_outline(matrix, x, y_crenel_top, x + crenel_w, base_top - 1, white)
+        x += crenel_w + crenel_gap
+
+    # Crenellations on the mid wall (outline blocks)
+    mid_crenel_h = max(1, int(castle_h * 0.025))
+    mid_crenel_w = max(1, int(castle_w * 0.04))
+    mid_crenel_gap = max(1, int(castle_w * 0.035))
+    x = mid_left + mid_crenel_gap
+    y_mid_crenel = mid_top - mid_crenel_h
+    while x + mid_crenel_w < mid_right - mid_crenel_gap:
+        _draw_rect_outline(matrix, x, y_mid_crenel, x + mid_crenel_w, mid_top - 1, white)
+        x += mid_crenel_w + mid_crenel_gap

--- a/docs/flow.svg
+++ b/docs/flow.svg
@@ -1,0 +1,221 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 1340" font-family="monospace" font-size="13">
+  <rect width="980" height="1340" fill="#0f1117"/>
+
+  <defs>
+    <marker id="arr"        markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#888"/></marker>
+    <marker id="arr-green"  markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#4caf50"/></marker>
+    <marker id="arr-purple" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#ce93d8"/></marker>
+    <marker id="arr-yellow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#ffd54f"/></marker>
+    <marker id="arr-indigo" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#7986cb"/></marker>
+    <marker id="arr-orange" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#ff7043"/></marker>
+  </defs>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- TITLE                                                      -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <text x="490" y="36" text-anchor="middle" fill="#ffffff" font-size="18" font-weight="bold">LightningLane Live LED — Full Data Flow</text>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- STARTUP BOX  y=55..115                                     -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <rect x="320" y="55" width="340" height="60" rx="8" fill="#1e3a5f" stroke="#4a9eff" stroke-width="2"/>
+  <text x="490" y="76"  text-anchor="middle" fill="#4a9eff" font-size="14" font-weight="bold">disney.py  (startup)</text>
+  <text x="490" y="93"  text-anchor="middle" fill="#a0c4ff" font-size="11">loads config.json · initialises fonts · spawns threads</text>
+  <text x="490" y="108" text-anchor="middle" fill="#a0c4ff" font-size="11">reads websocket_only flag</text>
+
+  <!-- startup → Thread A (left) -->
+  <line x1="390" y1="115" x2="220" y2="165" stroke="#4a9eff" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- startup → Thread B (right) -->
+  <line x1="590" y1="115" x2="760" y2="165" stroke="#4a9eff" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- startup → main display loop: dashed indigo runs in the gap x=420, well clear of both columns -->
+  <line x1="490" y1="115" x2="490" y2="780" stroke="#7986cb" stroke-width="1.5" stroke-dasharray="6,4" marker-end="url(#arr-indigo)"/>
+  <text x="498" y="450" fill="#7986cb" font-size="10">main thread</text>
+  <text x="498" y="463" fill="#7986cb" font-size="10">(display loop)</text>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- THREAD A — LEFT COLUMN  x=55..375                         -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+
+  <!-- A1: header  y=165..215 -->
+  <rect x="55" y="165" width="310" height="50" rx="8" fill="#1a3a1a" stroke="#4caf50" stroke-width="2"/>
+  <text x="210" y="185" text-anchor="middle" fill="#4caf50" font-size="13" font-weight="bold">Thread A — live_data_updater</text>
+  <text x="210" y="203" text-anchor="middle" fill="#a5d6a7" font-size="11">data_updater.py · loop every 5 min</text>
+
+  <!-- ── STARTUP-ONLY section label -->
+  <text x="210" y="232" text-anchor="middle" fill="#888" font-size="10">── startup only ──────────────────────────</text>
+
+  <line x1="210" y1="236" x2="210" y2="248" stroke="#4caf50" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <!-- A2: fetch_parks_and_attractions  y=248..300  (startup only) -->
+  <rect x="55" y="248" width="310" height="52" rx="6" fill="#0d2a0d" stroke="#4caf50" stroke-width="1" stroke-dasharray="6,3"/>
+  <text x="210" y="269" text-anchor="middle" fill="#81c784" font-weight="bold">fetch_parks_and_attractions()</text>
+  <text x="210" y="285" text-anchor="middle" fill="#a5d6a7" font-size="11">ThemeParks.wiki REST · park list + attr stubs</text>
+  <text x="210" y="299" text-anchor="middle" fill="#888" font-size="10">one-time at startup</text>
+
+  <line x1="210" y1="300" x2="210" y2="320" stroke="#4caf50" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <!-- A3: fetch_live_data  y=320..380  (startup always; loop only if websocket_only=false) -->
+  <rect x="55" y="320" width="310" height="60" rx="6" fill="#0d2a0d" stroke="#4caf50" stroke-width="1"/>
+  <text x="210" y="341" text-anchor="middle" fill="#81c784" font-weight="bold">fetch_live_data()  [async / aiohttp]</text>
+  <text x="210" y="357" text-anchor="middle" fill="#a5d6a7" font-size="11">GET /entity/{parkId}/live · all parks parallel</text>
+  <text x="210" y="373" text-anchor="middle" fill="#ffb74d" font-size="10">⚑ loop: only if websocket_only=false</text>
+
+  <line x1="210" y1="380" x2="210" y2="400" stroke="#4caf50" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <!-- A4: merge_live_data  y=400..458 -->
+  <rect x="55" y="400" width="310" height="58" rx="6" fill="#0d2a0d" stroke="#4caf50" stroke-width="1"/>
+  <text x="210" y="421" text-anchor="middle" fill="#81c784" font-weight="bold">merge_live_data()</text>
+  <text x="210" y="437" text-anchor="middle" fill="#a5d6a7" font-size="11">preserves down_since if already DOWN</text>
+  <text x="210" y="453" text-anchor="middle" fill="#ffb74d" font-size="10">⚑ loop: only if websocket_only=false</text>
+
+  <line x1="210" y1="458" x2="210" y2="478" stroke="#4caf50" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <!-- A5: get_down_time  y=478..530 -->
+  <rect x="55" y="478" width="310" height="52" rx="6" fill="#0d2a0d" stroke="#4caf50" stroke-width="1"/>
+  <text x="210" y="499" text-anchor="middle" fill="#81c784" font-weight="bold">get_down_time(down_since)</text>
+  <text x="210" y="515" text-anchor="middle" fill="#a5d6a7" font-size="11">fromisoformat · handles .ms · → elapsed min</text>
+  <text x="210" y="529" text-anchor="middle" fill="#ffb74d" font-size="10">⚑ loop: only if websocket_only=false</text>
+
+  <line x1="210" y1="530" x2="210" y2="550" stroke="#4caf50" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <!-- A6: fetch_weather_data  y=550..602  (always runs in loop) -->
+  <rect x="55" y="550" width="310" height="52" rx="6" fill="#1a1a00" stroke="#ffeb3b" stroke-width="1.5"/>
+  <text x="210" y="571" text-anchor="middle" fill="#ffeb3b" font-weight="bold">fetch_weather_data()</text>
+  <text x="210" y="587" text-anchor="middle" fill="#fff9c4" font-size="11">OpenWeatherMap · per operating park</text>
+  <text x="210" y="601" text-anchor="middle" fill="#ffeb3b" font-size="10">✓ always runs every 5 min (both modes)</text>
+
+  <!-- Thread A → shared state  (from bottom-right of A6) -->
+  <line x1="365" y1="576" x2="430" y2="686" stroke="#4caf50" stroke-width="1.5" marker-end="url(#arr-green)"/>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- THREAD B — RIGHT COLUMN  x=615..915                       -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+
+  <!-- B1: header  y=165..215 -->
+  <rect x="615" y="165" width="310" height="50" rx="8" fill="#3a1a3a" stroke="#ce93d8" stroke-width="2"/>
+  <text x="770" y="185" text-anchor="middle" fill="#ce93d8" font-size="13" font-weight="bold">Thread B — websocket_live_updater</text>
+  <text x="770" y="203" text-anchor="middle" fill="#e1bee7" font-size="11">websocket_updater.py · persistent connection</text>
+
+  <line x1="770" y1="215" x2="770" y2="248" stroke="#ce93d8" stroke-width="1.5" marker-end="url(#arr-purple)"/>
+
+  <!-- B2: WS connect  y=248..300 -->
+  <rect x="615" y="248" width="310" height="52" rx="6" fill="#2a0d2a" stroke="#ce93d8" stroke-width="1"/>
+  <text x="770" y="269" text-anchor="middle" fill="#ba68c8" font-weight="bold">wss://ws.themeparks.wiki/v1/live</text>
+  <text x="770" y="285" text-anchor="middle" fill="#e1bee7" font-size="11">subscribe → destination_id (per park)</text>
+  <text x="770" y="299" text-anchor="middle" fill="#e1bee7" font-size="10">real-time push on every status change</text>
+
+  <line x1="770" y1="300" x2="770" y2="320" stroke="#ce93d8" stroke-width="1.5" marker-end="url(#arr-purple)"/>
+
+  <!-- B3: apply update  y=320..380 -->
+  <rect x="615" y="320" width="310" height="60" rx="6" fill="#2a0d2a" stroke="#ce93d8" stroke-width="1"/>
+  <text x="770" y="341" text-anchor="middle" fill="#ba68c8" font-weight="bold">_apply_live_update(msg)</text>
+  <text x="770" y="357" text-anchor="middle" fill="#e1bee7" font-size="11">livedata event · ATTRACTION or SHOW</text>
+  <text x="770" y="373" text-anchor="middle" fill="#e1bee7" font-size="11">→ update waitTime / status in parks_data</text>
+
+  <line x1="770" y1="380" x2="770" y2="400" stroke="#ce93d8" stroke-width="1.5" marker-end="url(#arr-purple)"/>
+
+  <!-- B4: DOWN handler  y=400..458 -->
+  <rect x="615" y="400" width="310" height="58" rx="6" fill="#2a0d2a" stroke="#ce93d8" stroke-width="1"/>
+  <text x="770" y="421" text-anchor="middle" fill="#ba68c8" font-weight="bold">DOWN handler</text>
+  <text x="770" y="437" text-anchor="middle" fill="#e1bee7" font-size="11">set down_since on first DOWN (preserves after)</text>
+  <text x="770" y="453" text-anchor="middle" fill="#e1bee7" font-size="11">waitTime = "Down N min" via get_down_time()</text>
+
+  <line x1="770" y1="458" x2="770" y2="478" stroke="#ce93d8" stroke-width="1" stroke-dasharray="5,3" marker-end="url(#arr-purple)"/>
+
+  <!-- B5: reconnect  y=478..530  (dashed = conditional) -->
+  <rect x="615" y="478" width="310" height="52" rx="6" fill="#2a0d2a" stroke="#ce93d8" stroke-width="1" stroke-dasharray="5,3"/>
+  <text x="770" y="499" text-anchor="middle" fill="#ba68c8" font-weight="bold">on reconnect: REST refresh</text>
+  <text x="770" y="515" text-anchor="middle" fill="#e1bee7" font-size="11">await fetch_live_data() + merge_live_data()</text>
+  <text x="770" y="529" text-anchor="middle" fill="#e1bee7" font-size="10">re-seeds parks_data after WS drop</text>
+
+  <!-- Thread B → shared state  (from bottom of B5) -->
+  <line x1="770" y1="530" x2="556" y2="686" stroke="#ce93d8" stroke-width="1.5" marker-end="url(#arr-purple)"/>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- SHARED STATE  y=686..760                                   -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <rect x="190" y="686" width="580" height="64" rx="8" fill="#3a2a00" stroke="#ffd54f" stroke-width="2"/>
+  <text x="480" y="710" text-anchor="middle" fill="#ffd54f" font-size="14" font-weight="bold">parks_data [ ]  — shared in-memory list</text>
+  <text x="480" y="727" text-anchor="middle" fill="#ffe082" font-size="11">park · attractions · waitTime · status · down_since · weather</text>
+  <text x="480" y="742" text-anchor="middle" fill="#ffe082" font-size="11">updated in-place by both threads · read by main display thread</text>
+
+  <!-- shared state → display loop -->
+  <line x1="490" y1="750" x2="490" y2="780" stroke="#ffd54f" stroke-width="2" marker-end="url(#arr-yellow)"/>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- DISPLAY LOOP  y=780..1040                                  -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <rect x="110" y="780" width="760" height="260" rx="8" fill="#0d0d2a" stroke="#7986cb" stroke-width="2"/>
+  <text x="490" y="806" text-anchor="middle" fill="#7986cb" font-size="14" font-weight="bold">Main Thread — Display Loop  (disney.py)</text>
+  <text x="490" y="824" text-anchor="middle" fill="#9fa8da" font-size="11">cycles parks indefinitely · skips non-operating parks</text>
+
+  <!-- Row: Mickey → Countdown → Park Title -->
+  <rect x="132" y="838" width="150" height="36" rx="5" fill="#1a1a4a" stroke="#7986cb" stroke-width="1"/>
+  <text x="207" y="861" text-anchor="middle" fill="#c5cae9" font-size="12">Mickey Logo</text>
+
+  <line x1="282" y1="856" x2="304" y2="856" stroke="#7986cb" stroke-width="1.5" marker-end="url(#arr-indigo)"/>
+
+  <rect x="304" y="838" width="162" height="36" rx="5" fill="#1a1a4a" stroke="#7986cb" stroke-width="1"/>
+  <text x="385" y="861" text-anchor="middle" fill="#c5cae9" font-size="12">Trip Countdown</text>
+
+  <line x1="466" y1="856" x2="488" y2="856" stroke="#7986cb" stroke-width="1.5" marker-end="url(#arr-indigo)"/>
+
+  <rect x="488" y="838" width="194" height="36" rx="5" fill="#1a1a4a" stroke="#7986cb" stroke-width="1"/>
+  <text x="585" y="861" text-anchor="middle" fill="#c5cae9" font-size="12">Park Title + Weather</text>
+
+  <!-- arrow down to attractions -->
+  <line x1="490" y1="874" x2="490" y2="900" stroke="#7986cb" stroke-width="1.5" marker-end="url(#arr-indigo)"/>
+
+  <!-- loop_through_attractions -->
+  <rect x="220" y="900" width="540" height="44" rx="5" fill="#1a1a4a" stroke="#7986cb" stroke-width="1"/>
+  <text x="490" y="921" text-anchor="middle" fill="#c5cae9" font-size="12" font-weight="bold">loop_through_attractions()</text>
+  <text x="490" y="937" text-anchor="middle" fill="#9fa8da" font-size="11">reads parks_data · one attraction per 8 s frame</text>
+
+  <line x1="490" y1="944" x2="490" y2="968" stroke="#7986cb" stroke-width="1.5" marker-end="url(#arr-indigo)"/>
+
+  <!-- format box -->
+  <rect x="132" y="968" width="668" height="36" rx="5" fill="#1a1a4a" stroke="#7986cb" stroke-width="1"/>
+  <text x="490" y="991" text-anchor="middle" fill="#9fa8da" font-size="11">_format_wait_time()  →  "45 Mins"  |  "Down 12 min"  |  "Groups 1-50"  |  "Closed"</text>
+
+  <!-- repeats-forever arrow: right side of display loop box curves back to top -->
+  <path d="M 870 1010 Q 930 1010 930 790 Q 930 780 870 780" stroke="#7986cb" stroke-width="1.2" fill="none" stroke-dasharray="6,3" marker-end="url(#arr-indigo)"/>
+  <text x="946" y="900" fill="#7986cb" font-size="11" text-anchor="middle" transform="rotate(90,946,900)">repeats forever</text>
+
+  <!-- display loop → LED -->
+  <line x1="490" y1="1040" x2="490" y2="1076" stroke="#ff7043" stroke-width="2" marker-end="url(#arr-orange)"/>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- LED MATRIX  y=1076..1148                                   -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <rect x="290" y="1076" width="400" height="64" rx="8" fill="#1a0d00" stroke="#ff7043" stroke-width="2"/>
+  <text x="490" y="1100" text-anchor="middle" fill="#ff7043" font-size="14" font-weight="bold">RGB LED Matrix</text>
+  <text x="490" y="1118" text-anchor="middle" fill="#ffccbc" font-size="11">rgbmatrix (Raspberry Pi)  or  RGBMatrixEmulator</text>
+  <text x="490" y="1134" text-anchor="middle" fill="#ffccbc" font-size="11">driver/__init__.py auto-selects at startup</text>
+
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <!-- LEGEND  y=1168..1220                                       -->
+  <!-- ══════════════════════════════════════════════════════════ -->
+  <rect x="55" y="1168" width="870" height="102" rx="6" fill="#1a1a1a" stroke="#444" stroke-width="1"/>
+
+  <!-- row 1 -->
+  <rect x="76"  y="1182" width="12" height="12" fill="#4caf50"/>
+  <text x="94"  y="1193" fill="#a5d6a7" font-size="11">REST thread</text>
+  <rect x="200" y="1182" width="12" height="12" fill="#ce93d8"/>
+  <text x="218" y="1193" fill="#e1bee7" font-size="11">WebSocket thread (real-time)</text>
+  <rect x="440" y="1182" width="12" height="12" fill="#ffd54f"/>
+  <text x="458" y="1193" fill="#ffe082" font-size="11">Shared state</text>
+  <rect x="590" y="1182" width="12" height="12" fill="#7986cb"/>
+  <text x="608" y="1193" fill="#c5cae9" font-size="11">Main display thread</text>
+  <rect x="770" y="1182" width="12" height="12" fill="#ff7043"/>
+  <text x="788" y="1193" fill="#ffccbc" font-size="11">Hardware output</text>
+
+  <!-- row 2: mode notes -->
+  <rect x="76"  y="1210" width="12" height="12" fill="#0d2a0d" stroke="#4caf50" stroke-width="1"/>
+  <text x="94"  y="1221" fill="#a5d6a7" font-size="11">websocket_only=false: fetch_live_data + merge + get_down_time + weather run every 5 min</text>
+  <rect x="76"  y="1228" width="12" height="12" fill="#1a1a00" stroke="#ffeb3b" stroke-width="1"/>
+  <text x="94"  y="1239" fill="#fff9c4" font-size="11">websocket_only=true:  weather only runs every 5 min  ·  attraction data handled by Thread B</text>
+
+  <!-- ⚑ note -->
+  <text x="76"  y="1257" fill="#ffb74d" font-size="10">⚑ = skipped in loop when websocket_only=true     dashed border = startup-only or conditional</text>
+
+</svg>

--- a/emulator_config.json
+++ b/emulator_config.json
@@ -1,0 +1,33 @@
+{
+    "pixel_outline": 0,
+    "pixel_size": 16,
+    "pixel_style": "square",
+    "pixel_glow": 6,
+    "display_adapter": "browser",
+    "icon_path": null,
+    "emulator_title": null,
+    "suppress_font_warnings": false,
+    "suppress_adapter_load_errors": false,
+    "browser": {
+        "_comment": "For use with the browser adapter only.",
+        "port": 8888,
+        "target_fps": 60,
+        "fps_display": false,
+        "quality": 70,
+        "image_border": true,
+        "debug_text": false,
+        "image_format": "JPEG",
+        "open_immediately": false
+    },
+    "pi5": {
+        "_comment": "For use with the pi5 adapter only.",
+        "pinout": "AdafruitMatrixBonnet",
+        "n_addr_lines": 4,
+        "rotation": "Normal",
+        "n_planes": 10,
+        "n_temporal_planes": 4,
+        "n_lanes": 1,
+        "led_rgb_sequence": "RGB"
+    },
+    "log_level": "info"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Requirements for the Disney Ride Wait Time Display application
 aiohttp>=3.11.13
+certifi>=2024.0.0
 requests>=2.32.3
 Pillow>=10.0.1
 RGBMatrixEmulator>=0.13.3

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -23,6 +23,7 @@ from api.disney_api import (
     park_has_operating_attraction,
     update_parks_operating_status,
     handle_park_schedule_update,
+    refresh_park_attractions,
     resolve_destination_id,
     resolve_parks_from_config,
     DISNEY_WORLD_DESTINATION_ID,
@@ -588,6 +589,81 @@ def test_handle_park_schedule_update(monkeypatch):
     assert park["specialTicketedEvent"] is True
     assert park["openingTime"] == "09:00"
     assert park["closingTime"] == "22:00"
+
+def test_handle_park_schedule_update_calls_refresh(monkeypatch):
+    park = {"name": "Test Park", "id": "dummy-id", "schedule": [], "attractions": []}
+    monkeypatch.setattr("api.disney_api.fetch_park_schedule", lambda park_id: [])
+    refreshed = []
+    monkeypatch.setattr("api.disney_api.refresh_park_attractions", lambda p: refreshed.append(p))
+    handle_park_schedule_update(True, park)
+    assert refreshed == [park]
+
+def test_handle_park_schedule_update_no_refresh_when_already_operating(monkeypatch):
+    park = {"name": "Test Park", "id": "dummy-id", "schedule": [], "operating": True, "attractions": []}
+    monkeypatch.setattr("api.disney_api.fetch_park_schedule", lambda park_id: [])
+    refreshed = []
+    monkeypatch.setattr("api.disney_api.refresh_park_attractions", lambda p: refreshed.append(p))
+    handle_park_schedule_update(True, park)
+    assert refreshed == []
+
+###########
+# Tests for refresh_park_attractions
+###########
+
+def _make_children_response(children):
+    return DummyResponse({"children": children}, 200)
+
+def test_refresh_park_attractions_updates_name(monkeypatch):
+    park = {
+        "id": "park-1", "name": "Test Park",
+        "attractions": [{"id": "a1", "name": "Old Name", "waitTime": 10, "status": "OPERATING", "lastUpdatedTs": "ts"}]
+    }
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _make_children_response([
+        {"id": "a1", "name": "New Name", "entityType": "ATTRACTION"}
+    ]))
+    refresh_park_attractions(park)
+    assert park["attractions"][0]["name"] == "New Name"
+    assert park["attractions"][0]["waitTime"] == 10  # live data preserved
+
+def test_refresh_park_attractions_adds_new(monkeypatch):
+    park = {
+        "id": "park-1", "name": "Test Park",
+        "attractions": [{"id": "a1", "name": "Ride A", "waitTime": 5, "status": "OPERATING", "lastUpdatedTs": ""}]
+    }
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _make_children_response([
+        {"id": "a1", "name": "Ride A", "entityType": "ATTRACTION"},
+        {"id": "a2", "name": "Ride B", "entityType": "ATTRACTION"},
+    ]))
+    refresh_park_attractions(park)
+    ids = [a["id"] for a in park["attractions"]]
+    assert "a1" in ids and "a2" in ids
+    new = next(a for a in park["attractions"] if a["id"] == "a2")
+    assert new["waitTime"] == ""
+
+def test_refresh_park_attractions_removes_dropped(monkeypatch):
+    park = {
+        "id": "park-1", "name": "Test Park",
+        "attractions": [
+            {"id": "a1", "name": "Ride A", "waitTime": 5, "status": "OPERATING", "lastUpdatedTs": ""},
+            {"id": "a2", "name": "Ride B", "waitTime": 0, "status": "CLOSED", "lastUpdatedTs": ""},
+        ]
+    }
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _make_children_response([
+        {"id": "a1", "name": "Ride A", "entityType": "ATTRACTION"},
+    ]))
+    refresh_park_attractions(park)
+    assert len(park["attractions"]) == 1
+    assert park["attractions"][0]["id"] == "a1"
+
+def test_refresh_park_attractions_request_error(monkeypatch):
+    park = {
+        "id": "park-1", "name": "Test Park",
+        "attractions": [{"id": "a1", "name": "Ride A", "waitTime": 5, "status": "OPERATING", "lastUpdatedTs": ""}]
+    }
+    monkeypatch.setattr(requests, "get",
+                        lambda url, **kw: (_ for _ in ()).throw(requests.RequestException("err")))
+    refresh_park_attractions(park)
+    assert len(park["attractions"]) == 1  # unchanged on error
 
 def test_update_parks_operating_status(monkeypatch):
     park = {

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -394,8 +394,22 @@ def test_get_down_time_valid():
     # Allow a range since actual computation might vary slightly.
     assert 29 <= minutes <= 31
 
+def test_get_down_time_with_milliseconds():
+    past = datetime.now(timezone.utc) - timedelta(minutes=45)
+    past_iso = past.strftime('%Y-%m-%dT%H:%M:%S.') + f"{past.microsecond // 1000:03d}Z"
+    minutes = get_down_time(past_iso)
+    assert 44 <= minutes <= 46
+
 def test_get_down_time_invalid():
     result = get_down_time("invalid-date")
+    assert result is None
+
+def test_get_down_time_none_input():
+    result = get_down_time(None)
+    assert result is None
+
+def test_get_down_time_empty_string():
+    result = get_down_time("")
     assert result is None
 
 ###########

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -18,8 +18,9 @@ from api.disney_api import (
     is_special_event,
     determine_llmp_price,
     get_down_time,
-    fetch_live_data_for_attraction,
-    fetch_live_data,
+    fetch_park_live_data,
+    parse_queue_wait,
+    build_live_updates,
     park_has_operating_attraction,
     update_parks_operating_status,
     handle_park_schedule_update,
@@ -413,184 +414,168 @@ def test_get_down_time_empty_string():
     assert result is None
 
 ###########
-# Asynchronous Live Data Tests
+# Live Data Tests (per-park endpoint)
 ###########
-@pytest.mark.asyncio
-async def test_fetch_live_data_for_attraction_success(monkeypatch):
-    # Dummy live entry with status "OPERATING" that should update waitTime.
-    dummy_live_entry = {
-        "lastUpdated": "2023-10-01T12:00:00Z",
+
+def test_parse_queue_wait_standby():
+    assert parse_queue_wait({"STANDBY": {"waitTime": 45}}) == 45
+
+def test_parse_queue_wait_standby_takes_priority_over_boarding_group():
+    queue = {
+        "STANDBY": {"waitTime": 30},
+        "BOARDING_GROUP": {"currentGroupStart": 1, "currentGroupEnd": 50},
+    }
+    assert parse_queue_wait(queue) == 30
+
+def test_parse_queue_wait_boarding_group_range():
+    queue = {"BOARDING_GROUP": {"currentGroupStart": 1, "currentGroupEnd": 50}}
+    assert parse_queue_wait(queue) == "Groups 1-50"
+
+def test_parse_queue_wait_boarding_group_open_ended():
+    queue = {"BOARDING_GROUP": {"currentGroupStart": 10, "currentGroupEnd": None}}
+    assert parse_queue_wait(queue) == "Group 10+"
+
+def test_parse_queue_wait_boarding_group_closed():
+    queue = {"BOARDING_GROUP": {"currentGroupStart": None, "currentGroupEnd": None}}
+    assert parse_queue_wait(queue) is None
+
+def test_parse_queue_wait_empty_or_null_blocks():
+    assert parse_queue_wait({}) is None
+    assert parse_queue_wait({"STANDBY": None, "BOARDING_GROUP": None}) is None
+
+
+def test_build_live_updates_operating_attraction():
+    entries = [{
+        "id": "attr-1",
+        "entityType": "ATTRACTION",
         "status": "OPERATING",
+        "lastUpdated": "2023-10-01T12:00:00Z",
         "queue": {"STANDBY": {"waitTime": 45}},
-        "entityType": "ATTRACTION"
-    }
-
-    # Define a fake response that implements async context manager.
-    class FakeResponse:
-        def __init__(self, json_data, status=200):
-            self._json = json_data
-            self.status = status
-
-        async def json(self):
-            return self._json
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-    # Define a FakeSession with a normal get() method returning FakeResponse.
-    class FakeSession:
-        def get(self, url, **kwargs):
-            return FakeResponse({"liveData": [dummy_live_entry]}, 200)
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
-    # Create a dummy attraction with blank waitTime values.
-    dummy_attraction = {
-        "id": "attr-1",
-        "name": "Space Mountain",
-        "waitTime": '',
-        "status": '',
-        "lastUpdatedTs": ''
-    }
-
-    from api.disney_api import fetch_live_data_for_attraction
-    result = await fetch_live_data_for_attraction(FakeSession(), dummy_attraction)
-
-    # Assert that waitTime was updated to 45 (as an int),
-    # and that status and lastUpdatedTs are updated properly.
-    assert result["waitTime"] == 45, f"Expected waitTime 45, got {result['waitTime']}"
-    assert result["status"] == "OPERATING"
-    assert result["lastUpdatedTs"] == "2023-10-01T12:00:00Z"
-
-@pytest.mark.asyncio
-async def test_fetch_live_data_for_attraction_standby_takes_priority_over_boarding_group():
-    dummy_live_entry = {
-        "lastUpdated": "2023-10-01T12:00:00Z",
-        "status": "OPERATING",
-        "queue": {
-            "STANDBY": {"waitTime": 30},
-            "BOARDING_GROUP": {
-                "currentGroupStart": 1,
-                "currentGroupEnd": 50,
-                "allocationStatus": "OPEN",
-                "estimatedWait": None,
-                "nextAllocationTime": None
-            }
-        },
-        "entityType": "ATTRACTION"
-    }
-
-    class FakeResponse:
-        status = 200
-        async def json(self): return {"liveData": [dummy_live_entry]}
-        async def __aenter__(self): return self
-        async def __aexit__(self, *a): pass
-
-    class FakeSession:
-        def get(self, url, **kwargs): return FakeResponse()
-        async def __aenter__(self): return self
-        async def __aexit__(self, *a): pass
-
-    dummy_attraction = {"id": "attr-3", "name": "Test Ride", "waitTime": "", "status": "", "lastUpdatedTs": ""}
-    from api.disney_api import fetch_live_data_for_attraction
-    result = await fetch_live_data_for_attraction(FakeSession(), dummy_attraction)
-    assert result["waitTime"] == 30
-
-@pytest.mark.asyncio
-async def test_fetch_live_data_for_attraction_boarding_group_range():
-    dummy_live_entry = {
-        "lastUpdated": "2023-10-01T12:00:00Z",
-        "status": "OPERATING",
-        "queue": {
-            "BOARDING_GROUP": {
-                "currentGroupStart": 1,
-                "currentGroupEnd": 50,
-                "allocationStatus": "OPEN",
-                "estimatedWait": None,
-                "nextAllocationTime": None
-            }
-        },
-        "entityType": "ATTRACTION"
-    }
-
-    class FakeResponse:
-        status = 200
-        async def json(self): return {"liveData": [dummy_live_entry]}
-        async def __aenter__(self): return self
-        async def __aexit__(self, *a): pass
-
-    class FakeSession:
-        def get(self, url, **kwargs): return FakeResponse()
-        async def __aenter__(self): return self
-        async def __aexit__(self, *a): pass
-
-    dummy_attraction = {"id": "attr-2", "name": "Tron", "waitTime": "", "status": "", "lastUpdatedTs": ""}
-    from api.disney_api import fetch_live_data_for_attraction
-    result = await fetch_live_data_for_attraction(FakeSession(), dummy_attraction)
-    assert result["waitTime"] == "Groups 1-50"
-    assert result["status"] == "OPERATING"
-
-@pytest.mark.asyncio
-async def test_fetch_live_data_for_attraction_boarding_group_closed():
-    dummy_live_entry = {
-        "lastUpdated": "2023-10-01T12:00:00Z",
-        "status": "OPERATING",
-        "queue": {
-            "BOARDING_GROUP": {
-                "currentGroupStart": None,
-                "currentGroupEnd": None,
-                "allocationStatus": "CLOSED",
-                "estimatedWait": None,
-                "nextAllocationTime": None
-            }
-        },
-        "entityType": "ATTRACTION"
-    }
-
-    class FakeResponse:
-        status = 200
-        async def json(self): return {"liveData": [dummy_live_entry]}
-        async def __aenter__(self): return self
-        async def __aexit__(self, *a): pass
-
-    class FakeSession:
-        def get(self, url, **kwargs): return FakeResponse()
-        async def __aenter__(self): return self
-        async def __aexit__(self, *a): pass
-
-    dummy_attraction = {"id": "attr-2", "name": "Tron", "waitTime": "", "status": "", "lastUpdatedTs": ""}
-    from api.disney_api import fetch_live_data_for_attraction
-    result = await fetch_live_data_for_attraction(FakeSession(), dummy_attraction)
-    assert result["waitTime"] is None
-
-@pytest.mark.asyncio
-async def test_fetch_live_data_exception(monkeypatch):
-    class FakeSession:
-        async def get(self, url, **kwargs):
-            raise Exception("Live data error")
-        async def __aenter__(self):
-            return self
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda **kw: FakeSession())
-    dummy_attractions = [{
-        "id": "attr-1",
-        "name": "Space Mountain",
-        "waitTime": '',
-        "status": '',
-        "lastUpdatedTs": ''
     }]
-    result = await fetch_live_data(dummy_attractions)
-    assert result[0]["waitTime"] == ''
-    assert result[0]["status"] == ''
-    assert result[0]["lastUpdatedTs"] == ''
+    updates = build_live_updates(entries)
+    assert updates == [{
+        "id": "attr-1",
+        "status": "OPERATING",
+        "lastUpdatedTs": "2023-10-01T12:00:00Z",
+        "waitTime": 45,
+    }]
+
+def test_build_live_updates_filters_non_attraction_entities():
+    entries = [
+        {"id": "r-1", "entityType": "RESTAURANT", "status": "OPERATING", "lastUpdated": "ts"},
+        {"id": "p-1", "entityType": "PARK", "status": "OPERATING", "lastUpdated": "ts"},
+        {"id": "s-1", "entityType": "SHOW", "status": "OPERATING", "lastUpdated": "ts", "queue": {}},
+    ]
+    updates = build_live_updates(entries)
+    assert [u["id"] for u in updates] == ["s-1"]
+
+def test_build_live_updates_down_attraction_gets_down_wait(monkeypatch):
+    monkeypatch.setattr("api.disney_api.get_down_time", lambda ts: 12)
+    entries = [{
+        "id": "attr-1", "entityType": "ATTRACTION", "status": "DOWN",
+        "lastUpdated": "2023-10-01T12:00:00Z",
+    }]
+    updates = build_live_updates(entries)
+    assert updates[0]["waitTime"] == "Down 12"
+
+def test_build_live_updates_down_show_omits_wait_time():
+    entries = [{
+        "id": "show-1", "entityType": "SHOW", "status": "DOWN",
+        "lastUpdated": "2023-10-01T12:00:00Z",
+    }]
+    updates = build_live_updates(entries)
+    assert "waitTime" not in updates[0]
+    assert updates[0]["status"] == "DOWN"
+
+def test_build_live_updates_closed_omits_wait_time():
+    """CLOSED/REFURBISHMENT keep the last known wait time via omission."""
+    for status in ("CLOSED", "REFURBISHMENT"):
+        entries = [{
+            "id": "attr-1", "entityType": "ATTRACTION", "status": status,
+            "lastUpdated": "ts",
+        }]
+        updates = build_live_updates(entries)
+        assert "waitTime" not in updates[0]
+        assert updates[0]["status"] == status
+
+def test_build_live_updates_missing_queue_fields():
+    entries = [{
+        "id": "attr-1", "entityType": "ATTRACTION", "status": "OPERATING",
+        "lastUpdated": "ts",
+    }]
+    updates = build_live_updates(entries)
+    assert updates[0]["waitTime"] is None
+
+
+class _FakeLiveResponse:
+    def __init__(self, json_data=None, status=200, raise_on_json=False):
+        self._json = json_data
+        self.status = status
+        self._raise_on_json = raise_on_json
+
+    async def json(self):
+        if self._raise_on_json:
+            raise ValueError("bad json")
+        return self._json
+
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): pass
+
+
+class _FakeLiveSession:
+    def __init__(self, response=None, raise_on_get=False):
+        self._response = response
+        self._raise_on_get = raise_on_get
+        self.requested_urls = []
+
+    def get(self, url, **kwargs):
+        self.requested_urls.append(url)
+        if self._raise_on_get:
+            raise Exception("network error")
+        return self._response
+
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): pass
+
+
+DUMMY_PARK = {"id": "park-1", "name": "Magic Kingdom"}
+
+@pytest.mark.asyncio
+async def test_fetch_park_live_data_success(monkeypatch):
+    live = [{
+        "id": "attr-1", "entityType": "ATTRACTION", "status": "OPERATING",
+        "lastUpdated": "2023-10-01T12:00:00Z",
+        "queue": {"STANDBY": {"waitTime": 45}},
+    }]
+    session = _FakeLiveSession(_FakeLiveResponse({"liveData": live}))
+    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda **kw: session)
+    updates = await fetch_park_live_data(DUMMY_PARK)
+    assert updates[0]["waitTime"] == 45
+    assert session.requested_urls == ["https://api.themeparks.wiki/v1/entity/park-1/live"]
+
+@pytest.mark.asyncio
+async def test_fetch_park_live_data_rate_limited_returns_none(monkeypatch):
+    session = _FakeLiveSession(_FakeLiveResponse(status=429))
+    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda **kw: session)
+    assert await fetch_park_live_data(DUMMY_PARK) is None
+
+@pytest.mark.asyncio
+async def test_fetch_park_live_data_network_error_returns_none(monkeypatch):
+    session = _FakeLiveSession(raise_on_get=True)
+    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda **kw: session)
+    assert await fetch_park_live_data(DUMMY_PARK) is None
+
+@pytest.mark.asyncio
+async def test_fetch_park_live_data_bad_json_returns_none(monkeypatch):
+    session = _FakeLiveSession(_FakeLiveResponse(raise_on_json=True))
+    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda **kw: session)
+    assert await fetch_park_live_data(DUMMY_PARK) is None
+
+@pytest.mark.asyncio
+async def test_fetch_park_live_data_missing_livedata_key(monkeypatch):
+    session = _FakeLiveSession(_FakeLiveResponse({"id": "park-1"}))
+    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda **kw: session)
+    assert await fetch_park_live_data(DUMMY_PARK) == []
 
 ###########
 # Tests for Park Operating Status & Schedule Update

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -170,6 +170,14 @@ def test_resolve_parks_from_config_request_error(monkeypatch):
     result = resolve_parks_from_config(["Cedar Point"])
     assert result == []
 
+def test_resolve_parks_from_config_preserves_config_order(monkeypatch):
+    monkeypatch.setattr(requests, "get", _make_fake_get(monkeypatch))
+    result = resolve_parks_from_config(["Cedar Point", "EPCOT"])
+    assert [p["id"] for p in result] == ["cp-id", "ep-id"]
+
+    result2 = resolve_parks_from_config(["EPCOT", "Cedar Point"])
+    assert [p["id"] for p in result2] == ["ep-id", "cp-id"]
+
 ###########
 # Tests for HTTP Functions
 ###########

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -24,6 +24,7 @@ from api.disney_api import (
     update_parks_operating_status,
     handle_park_schedule_update,
     resolve_destination_id,
+    resolve_parks_from_config,
     DISNEY_WORLD_DESTINATION_ID,
 )
 
@@ -82,6 +83,92 @@ def test_resolve_destination_id_request_error(monkeypatch):
     monkeypatch.setattr(requests, "get",
                         lambda url, **kw: (_ for _ in ()).throw(requests.RequestException("err")))
     assert resolve_destination_id("Cedar Point") is None
+
+###########
+# Tests for resolve_parks_from_config
+###########
+
+FAKE_DESTINATIONS = {
+    "destinations": [
+        {
+            "id": DISNEY_WORLD_DESTINATION_ID,
+            "name": "Walt Disney World® Resort",
+            "parks": [
+                {"id": "mk-id", "name": "Magic Kingdom Park"},
+                {"id": "ep-id", "name": "EPCOT"},
+            ],
+        },
+        {
+            "id": "cedar-dest-id",
+            "name": "Cedar Point",
+            "parks": [
+                {"id": "cp-id", "name": "Cedar Point"},
+                {"id": "cps-id", "name": "Cedar Point Shores"},
+            ],
+        },
+    ]
+}
+
+FAKE_WDW_SCHEDULE = {
+    "parks": [
+        {"id": "mk-id", "name": "Magic Kingdom Park", "schedule": []},
+        {"id": "ep-id", "name": "EPCOT", "schedule": []},
+    ]
+}
+
+FAKE_CEDAR_SCHEDULE = {
+    "parks": [
+        {"id": "cp-id", "name": "Cedar Point", "schedule": []},
+        {"id": "cps-id", "name": "Cedar Point Shores", "schedule": []},
+    ]
+}
+
+def _make_fake_get(monkeypatch):
+    def fake_get(url, **kwargs):
+        if url.endswith("/destinations"):
+            return DummyResponse(FAKE_DESTINATIONS, 200)
+        elif DISNEY_WORLD_DESTINATION_ID in url and "schedule" in url:
+            return DummyResponse(FAKE_WDW_SCHEDULE, 200)
+        elif "cedar-dest-id" in url and "schedule" in url:
+            return DummyResponse(FAKE_CEDAR_SCHEDULE, 200)
+        else:
+            return DummyResponse({"location": None}, 200)
+    return fake_get
+
+def test_resolve_parks_from_config_by_raw_name(monkeypatch):
+    monkeypatch.setattr(requests, "get", _make_fake_get(monkeypatch))
+    result = resolve_parks_from_config(["Cedar Point"])
+    assert len(result) == 1
+    assert result[0]["id"] == "cp-id"
+
+def test_resolve_parks_from_config_by_cleaned_disney_name(monkeypatch):
+    monkeypatch.setattr(requests, "get", _make_fake_get(monkeypatch))
+    result = resolve_parks_from_config(["Magic Kingdom"])
+    assert len(result) == 1
+    assert result[0]["id"] == "mk-id"
+
+def test_resolve_parks_from_config_cross_destination(monkeypatch):
+    monkeypatch.setattr(requests, "get", _make_fake_get(monkeypatch))
+    result = resolve_parks_from_config(["EPCOT", "Cedar Point"])
+    ids = {p["id"] for p in result}
+    assert ids == {"ep-id", "cp-id"}
+
+def test_resolve_parks_from_config_empty_defaults_to_wdw(monkeypatch):
+    monkeypatch.setattr(requests, "get", _make_fake_get(monkeypatch))
+    result = resolve_parks_from_config([])
+    ids = {p["id"] for p in result}
+    assert "mk-id" in ids and "ep-id" in ids
+
+def test_resolve_parks_from_config_no_match(monkeypatch):
+    monkeypatch.setattr(requests, "get", _make_fake_get(monkeypatch))
+    result = resolve_parks_from_config(["Nonexistent Park"])
+    assert result == []
+
+def test_resolve_parks_from_config_request_error(monkeypatch):
+    monkeypatch.setattr(requests, "get",
+                        lambda url, **kw: (_ for _ in ()).throw(requests.RequestException("err")))
+    result = resolve_parks_from_config(["Cedar Point"])
+    assert result == []
 
 ###########
 # Tests for HTTP Functions
@@ -444,7 +531,7 @@ async def test_fetch_live_data_exception(monkeypatch):
             return self
         async def __aexit__(self, exc_type, exc, tb):
             pass
-    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda: FakeSession())
+    monkeypatch.setattr("api.disney_api.aiohttp.ClientSession", lambda **kw: FakeSession())
     dummy_attractions = [{
         "id": "attr-1",
         "name": "Space Mountain",

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -304,6 +304,31 @@ def test_fetch_parks_and_attractions_includes_shows(monkeypatch):
     assert "show-1" in ids
     assert "other-1" not in ids
 
+def test_fetch_parks_and_attractions_includes_destination_id(monkeypatch):
+    today_str = datetime.now().strftime('%Y-%m-%d')
+    fake_parks_list = [{
+        "id": "dummy-id",
+        "name": "Magic Kingdom",
+        "destination_id": "dest-abc",
+        "schedule": [{"date": today_str, "type": "OPERATING", "openingTime": "09:00", "closingTime": "22:00"}],
+        "weather": [],
+        "location": {"latitude": 28.3759, "longitude": -81.5494},
+    }]
+
+    def fake_get(url, **kwargs):
+        if "children" in url:
+            return DummyResponse({"children": [
+                {"id": "attr-1", "name": "Space Mountain", "entityType": "ATTRACTION"}
+            ]}, 200)
+        return DummyResponse({}, 200)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(disney_api, "fetch_weather_data", lambda lat, lon: {})
+    result = fetch_parks_and_attractions(fake_parks_list)
+    assert len(result) == 1
+    assert result[0]["destination_id"] == "dest-abc"
+
+
 def test_fetch_parks_and_attractions_exception(monkeypatch):
     fake_parks_list = [{
         "id": "dummy-id",

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -14,6 +14,7 @@ from api.disney_api import (
     fetch_list_of_disney_world_parks,
     fetch_parks_and_attractions,
     get_attraction_name,
+    clean_park_name,
     is_special_event,
     determine_llmp_price,
     get_down_time,
@@ -21,7 +22,9 @@ from api.disney_api import (
     fetch_live_data,
     park_has_operating_attraction,
     update_parks_operating_status,
-    handle_park_schedule_update
+    handle_park_schedule_update,
+    resolve_destination_id,
+    DISNEY_WORLD_DESTINATION_ID,
 )
 
 ###########
@@ -49,6 +52,36 @@ DUMMY_PARKS = [{
         "lastUpdatedTs": "old"
     }]
 }]
+
+###########
+# Tests for resolve_destination_id
+###########
+
+def test_resolve_destination_id_passthrough_uuid(monkeypatch):
+    # A valid UUID should be returned as-is without any HTTP call.
+    called = []
+    monkeypatch.setattr(requests, "get", lambda url, **kw: called.append(url) or None)
+    result = resolve_destination_id(DISNEY_WORLD_DESTINATION_ID)
+    assert result == DISNEY_WORLD_DESTINATION_ID
+    assert called == []
+
+def test_resolve_destination_id_by_name(monkeypatch):
+    fake_destinations = {"destinations": [
+        {"id": "abc-123", "name": "Cedar Point"},
+        {"id": DISNEY_WORLD_DESTINATION_ID, "name": "Walt Disney World Resort"},
+    ]}
+    monkeypatch.setattr(requests, "get", lambda url, **kw: DummyResponse(fake_destinations, 200))
+    assert resolve_destination_id("Cedar Point") == "abc-123"
+    assert resolve_destination_id("walt disney world resort") == DISNEY_WORLD_DESTINATION_ID
+
+def test_resolve_destination_id_not_found(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda url, **kw: DummyResponse({"destinations": []}, 200))
+    assert resolve_destination_id("Nonexistent Park") is None
+
+def test_resolve_destination_id_request_error(monkeypatch):
+    monkeypatch.setattr(requests, "get",
+                        lambda url, **kw: (_ for _ in ()).throw(requests.RequestException("err")))
+    assert resolve_destination_id("Cedar Point") is None
 
 ###########
 # Tests for HTTP Functions
@@ -151,6 +184,30 @@ def test_fetch_parks_and_attractions_success(monkeypatch):
     attraction = park["attractions"][0]
     assert get_attraction_name({"name": "Space Mountain\u2122"}) == "Space Mountain"
 
+def test_fetch_parks_and_attractions_includes_shows(monkeypatch):
+    today_str = datetime.now().strftime('%Y-%m-%d')
+    fake_parks_list = [{
+        "id": "dummy-id",
+        "name": "Animal Kingdom",
+        "schedule": [{"date": today_str, "type": "OPERATING", "openingTime": "09:00", "closingTime": "22:00"}],
+        "weather": [],
+        "location": {"latitude": 28.3600, "longitude": -81.5900}
+    }]
+    def fake_get(url, **kwargs):
+        if "children" in url:
+            return DummyResponse({"children": [
+                {"id": "show-1", "name": "Bluey's Wild World at Conservation Station", "entityType": "SHOW"},
+                {"id": "other-1", "name": "Flame Tree BBQ", "entityType": "RESTAURANT"},
+            ]}, 200)
+        return DummyResponse({}, 200)
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(disney_api, "fetch_weather_data", lambda lat, lon: {})
+    result = fetch_parks_and_attractions(fake_parks_list)
+    attractions = result[0]["attractions"]
+    ids = [a["id"] for a in attractions]
+    assert "show-1" in ids
+    assert "other-1" not in ids
+
 def test_fetch_parks_and_attractions_exception(monkeypatch):
     fake_parks_list = [{
         "id": "dummy-id",
@@ -177,6 +234,12 @@ def test_get_attraction_name():
     assert "™" not in clean_name
     assert "–" not in clean_name
     assert "Halloween" not in clean_name
+
+def test_clean_park_name():
+    assert clean_park_name("Disney's Animal Kingdom Theme Park") == "Animal Kingdom"
+    assert clean_park_name("Magic Kingdom Park") == "Magic Kingdom"
+    assert clean_park_name("Disney's Hollywood Studios") == "Hollywood Studios"
+    assert clean_park_name("EPCOT") == "EPCOT"
 
 def test_is_special_event():
     schedule = [{
@@ -270,6 +333,107 @@ async def test_fetch_live_data_for_attraction_success(monkeypatch):
     assert result["waitTime"] == 45, f"Expected waitTime 45, got {result['waitTime']}"
     assert result["status"] == "OPERATING"
     assert result["lastUpdatedTs"] == "2023-10-01T12:00:00Z"
+
+@pytest.mark.asyncio
+async def test_fetch_live_data_for_attraction_standby_takes_priority_over_boarding_group():
+    dummy_live_entry = {
+        "lastUpdated": "2023-10-01T12:00:00Z",
+        "status": "OPERATING",
+        "queue": {
+            "STANDBY": {"waitTime": 30},
+            "BOARDING_GROUP": {
+                "currentGroupStart": 1,
+                "currentGroupEnd": 50,
+                "allocationStatus": "OPEN",
+                "estimatedWait": None,
+                "nextAllocationTime": None
+            }
+        },
+        "entityType": "ATTRACTION"
+    }
+
+    class FakeResponse:
+        status = 200
+        async def json(self): return {"liveData": [dummy_live_entry]}
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    class FakeSession:
+        def get(self, url, **kwargs): return FakeResponse()
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    dummy_attraction = {"id": "attr-3", "name": "Test Ride", "waitTime": "", "status": "", "lastUpdatedTs": ""}
+    from api.disney_api import fetch_live_data_for_attraction
+    result = await fetch_live_data_for_attraction(FakeSession(), dummy_attraction)
+    assert result["waitTime"] == 30
+
+@pytest.mark.asyncio
+async def test_fetch_live_data_for_attraction_boarding_group_range():
+    dummy_live_entry = {
+        "lastUpdated": "2023-10-01T12:00:00Z",
+        "status": "OPERATING",
+        "queue": {
+            "BOARDING_GROUP": {
+                "currentGroupStart": 1,
+                "currentGroupEnd": 50,
+                "allocationStatus": "OPEN",
+                "estimatedWait": None,
+                "nextAllocationTime": None
+            }
+        },
+        "entityType": "ATTRACTION"
+    }
+
+    class FakeResponse:
+        status = 200
+        async def json(self): return {"liveData": [dummy_live_entry]}
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    class FakeSession:
+        def get(self, url, **kwargs): return FakeResponse()
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    dummy_attraction = {"id": "attr-2", "name": "Tron", "waitTime": "", "status": "", "lastUpdatedTs": ""}
+    from api.disney_api import fetch_live_data_for_attraction
+    result = await fetch_live_data_for_attraction(FakeSession(), dummy_attraction)
+    assert result["waitTime"] == "Groups 1-50"
+    assert result["status"] == "OPERATING"
+
+@pytest.mark.asyncio
+async def test_fetch_live_data_for_attraction_boarding_group_closed():
+    dummy_live_entry = {
+        "lastUpdated": "2023-10-01T12:00:00Z",
+        "status": "OPERATING",
+        "queue": {
+            "BOARDING_GROUP": {
+                "currentGroupStart": None,
+                "currentGroupEnd": None,
+                "allocationStatus": "CLOSED",
+                "estimatedWait": None,
+                "nextAllocationTime": None
+            }
+        },
+        "entityType": "ATTRACTION"
+    }
+
+    class FakeResponse:
+        status = 200
+        async def json(self): return {"liveData": [dummy_live_entry]}
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    class FakeSession:
+        def get(self, url, **kwargs): return FakeResponse()
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+
+    dummy_attraction = {"id": "attr-2", "name": "Tron", "waitTime": "", "status": "", "lastUpdatedTs": ""}
+    from api.disney_api import fetch_live_data_for_attraction
+    result = await fetch_live_data_for_attraction(FakeSession(), dummy_attraction)
+    assert result["waitTime"] is None
 
 @pytest.mark.asyncio
 async def test_fetch_live_data_exception(monkeypatch):

--- a/tests/api/test_disney_api.py
+++ b/tests/api/test_disney_api.py
@@ -619,9 +619,10 @@ def test_handle_park_schedule_update(monkeypatch):
     monkeypatch.setattr("api.disney_api.fetch_park_schedule", lambda park_id: dummy_schedule)
     # Patch is_special_event to return True.
     monkeypatch.setattr("api.disney_api.is_special_event", lambda sch: True)
+    monkeypatch.setattr("api.disney_api.refresh_park_attractions", lambda p: None)
     # Capture debug info if desired.
     from api.disney_api import handle_park_schedule_update
-    handle_park_schedule_update(True, park)
+    handle_park_schedule_update(park)
     # Verify that schedule is updated, and llmpPrice and specialTicketedEvent are set.
     assert park["schedule"] == dummy_schedule
     assert park["llmpPrice"] == "$25"
@@ -634,16 +635,53 @@ def test_handle_park_schedule_update_calls_refresh(monkeypatch):
     monkeypatch.setattr("api.disney_api.fetch_park_schedule", lambda park_id: [])
     refreshed = []
     monkeypatch.setattr("api.disney_api.refresh_park_attractions", lambda p: refreshed.append(p))
-    handle_park_schedule_update(True, park)
+    handle_park_schedule_update(park)
     assert refreshed == [park]
 
-def test_handle_park_schedule_update_no_refresh_when_already_operating(monkeypatch):
-    park = {"name": "Test Park", "id": "dummy-id", "schedule": [], "operating": True, "attractions": []}
-    monkeypatch.setattr("api.disney_api.fetch_park_schedule", lambda park_id: [])
+def test_update_parks_operating_status_no_refresh_when_already_operating(monkeypatch):
+    park = {
+        "name": "Test Park", "id": "dummy-id", "schedule": [], "operating": True,
+        "attractions": [{"name": "Ride A", "waitTime": "10", "status": "OPERATING"}],
+    }
+    monkeypatch.setattr("api.disney_api.fetch_park_schedule",
+                        lambda park_id: (_ for _ in ()).throw(AssertionError("schedule fetched")))
     refreshed = []
     monkeypatch.setattr("api.disney_api.refresh_park_attractions", lambda p: refreshed.append(p))
-    handle_park_schedule_update(True, park)
+    updated = update_parks_operating_status([park])
+    assert updated[0]["operating"] is True
     assert refreshed == []
+    assert not updated[0].get("schedule_refresh_needed")
+
+def test_update_parks_operating_status_defers_schedule_fetch(monkeypatch):
+    """fetch_schedules=False (WS thread): transition flags the park but does no HTTP."""
+    park = {
+        "name": "Test Park", "id": "dummy-id", "schedule": [],
+        "attractions": [{"name": "Ride A", "waitTime": "10", "status": "OPERATING"}],
+    }
+    monkeypatch.setattr("api.disney_api.fetch_park_schedule",
+                        lambda park_id: (_ for _ in ()).throw(AssertionError("schedule fetched")))
+    monkeypatch.setattr("api.disney_api.refresh_park_attractions",
+                        lambda p: (_ for _ in ()).throw(AssertionError("attractions refreshed")))
+    updated = update_parks_operating_status([park], fetch_schedules=False)
+    assert updated[0]["operating"] is True
+    assert updated[0]["schedule_refresh_needed"] is True
+
+def test_update_parks_operating_status_consumes_deferred_flag(monkeypatch):
+    """fetch_schedules=True (REST thread): a pending flag triggers the fetch and is cleared."""
+    park = {
+        "name": "Test Park", "id": "dummy-id", "schedule": [],
+        "operating": True, "schedule_refresh_needed": True,
+        "attractions": [{"name": "Ride A", "waitTime": "10", "status": "OPERATING"}],
+    }
+    monkeypatch.setattr("api.disney_api.fetch_park_schedule", lambda park_id: [{
+        "type": "OPERATING", "openingTime": "09:00", "closingTime": "22:00"
+    }])
+    refreshed = []
+    monkeypatch.setattr("api.disney_api.refresh_park_attractions", lambda p: refreshed.append(p))
+    updated = update_parks_operating_status([park])
+    assert updated[0]["schedule_refresh_needed"] is False
+    assert updated[0]["openingTime"] == "09:00"
+    assert refreshed == [park]
 
 ###########
 # Tests for refresh_park_attractions
@@ -722,5 +760,6 @@ def test_update_parks_operating_status(monkeypatch):
         "closingTime": "22:00"
     }])
     monkeypatch.setattr("api.disney_api.fetch_weather_data", lambda lat, lon: {"temp": "dummy"})
+    monkeypatch.setattr("api.disney_api.refresh_park_attractions", lambda p: None)
     updated = update_parks_operating_status(copy.deepcopy(parks))
     assert updated[0]["operating"] is True

--- a/tests/display/attractions/test_attraction_info.py
+++ b/tests/display/attractions/test_attraction_info.py
@@ -92,3 +92,70 @@ def test_render_attraction_info(monkeypatch):
     # For basic test purposes, just check that render_attraction_info runs without KeyError.
     # (More in-depth tests would patch graphics.DrawText to record draw calls.)
     assert True
+
+
+def test_boarding_group_3digit_fits_32row(monkeypatch):
+    """Groups 100-200 on a 32-row board: all draw calls must land within board height."""
+    import display.attractions.attraction_info as mod
+
+    loaded_fonts["ride"] = DummyFont(width=5, height=8)
+    loaded_fonts["waittime"] = DummyFont(width=4, height=6)
+
+    calls = []
+    monkeypatch.setattr(mod.graphics, "DrawText", lambda matrix, font, x, y, color, text: calls.append((y, text)))
+
+    class FakeMatrix:
+        width, height = 32, 32
+        def Clear(self): pass
+
+    mod.render_attraction_info(
+        FakeMatrix(),
+        {"name": "Tron", "entityType": "ATTRACTION", "waitTime": "Groups 100-200", "status": "OPERATING"}
+    )
+    assert calls, "No DrawText calls were made"
+    for y, text in calls:
+        assert y <= 32, f"Text '{text}' drawn at y={y}, outside 32-row board"
+
+
+def test_boarding_group_3digit_fits_64row(monkeypatch):
+    """Groups 100-200 on a 64-row board: all draw calls must land within board height."""
+    import display.attractions.attraction_info as mod
+
+    loaded_fonts["ride"] = DummyFont(width=5, height=8)
+    loaded_fonts["waittime"] = DummyFont(width=5, height=8)
+
+    calls = []
+    monkeypatch.setattr(mod.graphics, "DrawText", lambda matrix, font, x, y, color, text: calls.append((y, text)))
+
+    class FakeMatrix:
+        width, height = 64, 64
+        def Clear(self): pass
+
+    mod.render_attraction_info(
+        FakeMatrix(),
+        {"name": "Tron", "entityType": "ATTRACTION", "waitTime": "Groups 100-200", "status": "OPERATING"}
+    )
+    assert calls, "No DrawText calls were made"
+    for y, text in calls:
+        assert y <= 64, f"Text '{text}' drawn at y={y}, outside 64-row board"
+
+
+def test_wait_time_formatting_integer():
+    """Numeric wait times get ' Mins' appended."""
+    from display.attractions.attraction_info import _format_wait_time
+    assert _format_wait_time(45) == "45 Mins"
+
+def test_wait_time_formatting_down():
+    """'Down X' strings still get ' Mins' appended."""
+    from display.attractions.attraction_info import _format_wait_time
+    assert _format_wait_time("Down 15") == "Down 15 Mins"
+
+def test_wait_time_formatting_boarding_group_range():
+    """Boarding group range strings are used as-is."""
+    from display.attractions.attraction_info import _format_wait_time
+    assert _format_wait_time("Groups 1-50") == "Groups 1-50"
+
+def test_wait_time_formatting_boarding_group_single():
+    """Single boarding group strings are used as-is."""
+    from display.attractions.attraction_info import _format_wait_time
+    assert _format_wait_time("Group 1+") == "Group 1+"

--- a/tests/test_disney.py
+++ b/tests/test_disney.py
@@ -158,6 +158,41 @@ def test_loop_through_attractions_skips_closed(monkeypatch):
     assert "Haunted Mansion" not in fake_matrix.rendered_attractions
 
 
+def test_loop_through_attractions_skips_empty_wait_time(monkeypatch):
+    fake_matrix = FakeMatrix()
+
+    def fake_render_attraction_info(matrix, attraction_info):
+        matrix.rendered_attractions.append(attraction_info['name'])
+
+    monkeypatch.setattr(disney, "render_attraction_info", fake_render_attraction_info)
+
+    park = {
+        "name": "Hollywood Studios",
+        "attractions": [
+            {"name": "Meet Disney Jr. Stars", "waitTime": "", "status": ""},
+            {"name": "Tron", "waitTime": "25", "status": "OPERATING"}
+        ]
+    }
+    disney.loop_through_attractions(fake_matrix, park)
+
+    assert "Tron" in fake_matrix.rendered_attractions
+    assert "Meet Disney Jr. Stars" not in fake_matrix.rendered_attractions
+
+
+def test_park_filter_limits_parks(monkeypatch):
+    from api.disney_api import clean_park_name
+    all_parks = [
+        {"name": "Disney's Animal Kingdom Theme Park", "id": "ak-id"},
+        {"name": "Magic Kingdom Park", "id": "mk-id"},
+        {"name": "Disney's Hollywood Studios", "id": "hs-id"},
+        {"name": "EPCOT", "id": "ep-id"},
+    ]
+    park_filter = ["Animal Kingdom"]
+    filtered = [p for p in all_parks if clean_park_name(p["name"]) in park_filter]
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == "ak-id"
+
+
 # Test that show_trip_countdown passes along the correct next_trip_time.
 def test_show_trip_countdown_format(monkeypatch):
     fake_matrix = FakeMatrix()

--- a/tests/updater/test_data_updater.py
+++ b/tests/updater/test_data_updater.py
@@ -294,3 +294,76 @@ def test_merge_live_data_no_change():
     result = merge_live_data(copy.deepcopy(existing), new_live)
     # Expect the output to be identical to the original existing data.
     assert result == existing
+
+
+def test_update_parks_live_data_websocket_skips_http_fetch(monkeypatch):
+    """When use_websocket=True, fetch_live_data must not be called."""
+    called = []
+
+    async def should_not_be_called(attractions):
+        called.append(True)
+        return []
+
+    monkeypatch.setattr("updater.data_updater.fetch_live_data", should_not_be_called)
+
+    parks_copy = copy.deepcopy(DUMMY_PARKS)
+    update_parks_live_data(parks_copy, use_websocket=True)
+
+    assert called == [], "fetch_live_data should not be called when use_websocket=True"
+
+
+def test_update_parks_live_data_no_websocket_calls_http_fetch(monkeypatch):
+    """When use_websocket=False (default), fetch_live_data must be called."""
+    called = []
+
+    async def dummy_fetch_live_data(attractions):
+        called.append(True)
+        return attractions
+
+    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch_live_data)
+
+    parks_copy = copy.deepcopy(DUMMY_PARKS)
+    update_parks_live_data(parks_copy, use_websocket=False)
+
+    assert called == [True], "fetch_live_data should be called when use_websocket=False"
+
+
+def test_live_data_updater_websocket_does_initial_fetch_then_skips_polling(monkeypatch):
+    """
+    live_data_updater with use_websocket=True must call fetch_live_data once for the
+    initial population, then skip it in the polling loop.
+    """
+    parks_data = []
+    fetch_call_count = []
+
+    async def counting_fetch(attractions):
+        fetch_call_count.append(1)
+        return attractions
+
+    monkeypatch.setattr("updater.data_updater.fetch_live_data", counting_fetch)
+    monkeypatch.setattr("updater.data_updater.fetch_parks_and_attractions", lambda parks: copy.deepcopy(DUMMY_PARKS))
+    monkeypatch.setattr("updater.data_updater.update_parks_operating_status", lambda parks: parks)
+
+    loop_iterations = []
+
+    def fake_sleep(duration):
+        loop_iterations.append(1)
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr("updater.data_updater.time", type("t", (), {"sleep": fake_sleep}))
+
+    updater_thread = threading.Thread(
+        target=live_data_updater,
+        args=(copy.deepcopy(DUMMY_PARKS), 0, parks_data),
+        kwargs={"use_websocket": True},
+        daemon=True,
+    )
+    try:
+        updater_thread.start()
+        updater_thread.join(timeout=2)
+    except KeyboardInterrupt:
+        pass
+
+    # fetch_live_data called exactly once (initial fetch), not again in the loop
+    assert len(fetch_call_count) == 1, "fetch_live_data should be called once for the initial fetch"
+    assert loop_iterations == [1], "polling loop should have run once then stopped"

--- a/tests/updater/test_data_updater.py
+++ b/tests/updater/test_data_updater.py
@@ -187,6 +187,48 @@ def test_merge_live_data_ignores_unknown_ids():
     assert result[0]["waitTime"] == 15
 
 
+def test_merge_live_data_mutates_in_place():
+    """merge must return the same list and same dict objects it was given —
+    rebuilding either would drop concurrent WS-thread updates."""
+    existing = [{
+        "id": "1",
+        "waitTime": 10,
+        "status": "OPERATING",
+        "down_since": "",
+        "lastUpdatedTs": "old",
+    }]
+    original_attr = existing[0]
+    result = merge_live_data(existing, [
+        {"id": "1", "waitTime": 15, "status": "OPERATING", "lastUpdatedTs": "new"},
+    ])
+    assert result is existing
+    assert result[0] is original_attr
+    assert original_attr["waitTime"] == 15
+
+
+class SpyLock:
+    def __init__(self):
+        self.acquisitions = 0
+
+    def __enter__(self):
+        self.acquisitions += 1
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_update_parks_live_data_merges_under_lock(monkeypatch):
+    async def ok_fetch(park):
+        return [{"id": "1", "waitTime": 12, "status": "OPERATING", "lastUpdatedTs": "new"}]
+
+    spy = SpyLock()
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", ok_fetch)
+    monkeypatch.setattr("updater.data_updater.parks_data_lock", spy)
+    update_parks_live_data(copy.deepcopy(DUMMY_PARKS))
+    assert spy.acquisitions == 1
+
+
 def test_merge_live_data_preserves_wait_time_when_omitted():
     """A CLOSED update omits waitTime; the last known value must survive."""
     existing = [{

--- a/tests/updater/test_data_updater.py
+++ b/tests/updater/test_data_updater.py
@@ -25,7 +25,7 @@ DUMMY_PARKS = [{
 def test_update_parks_live_data(monkeypatch):
     """
     Assume update_parks_live_data takes a parks list and updates each park's attractions
-    using live data. For testing, we patch updater.data_updater.fetch_live_data to return dummy live data.
+    using live data. For testing, we patch updater.data_updater.fetch_park_live_data to return dummy live data.
     """
     # Dummy live data that should update the attraction.
     dummy_live_data = [{
@@ -39,7 +39,7 @@ def test_update_parks_live_data(monkeypatch):
         return dummy_live_data
 
     # Patch fetch_live_data inside updater.data_updater.
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch_live_data)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", dummy_fetch_live_data)
 
     # Call update_parks_live_data with a copy of the dummy parks.
     parks_copy = copy.deepcopy(DUMMY_PARKS)
@@ -56,7 +56,7 @@ def test_update_parks_live_data(monkeypatch):
 def test_live_data_updater(monkeypatch):
     """
     Test live_data_updater by running it in a separate thread and forcing it to break out
-    after one iteration. We patch updater.data_updater.fetch_live_data to return updated live data,
+    after one iteration. We patch updater.data_updater.fetch_park_live_data to return updated live data,
     and patch time.sleep along with fetch_parks_and_attractions to bypass real HTTP calls.
     """
     parks_data = []
@@ -73,7 +73,7 @@ def test_live_data_updater(monkeypatch):
         return dummy_live_data
 
     # Patch fetch_live_data inside updater.data_updater.
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch_live_data)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", dummy_fetch_live_data)
 
     # Patch fetch_parks_and_attractions to return the parks unchanged.
     monkeypatch.setattr("updater.data_updater.fetch_parks_and_attractions", lambda parks: parks)
@@ -157,7 +157,9 @@ def test_merge_live_data_down_since_handling():
     assert result2[0]["down_since"] == ""
 
 
-def test_merge_live_data_appends_new():
+def test_merge_live_data_ignores_unknown_ids():
+    """Live updates carry no name/entityType, so unknown ids must be skipped —
+    roster additions are handled by refresh_park_attractions."""
     existing = [{
         "id": "1",
         "waitTime": 10,
@@ -180,13 +182,51 @@ def test_merge_live_data_appends_new():
         },
     ]
     result = merge_live_data(copy.deepcopy(existing), new_live)
-    assert len(result) == 2
-    ids = {a["id"] for a in result}
-    assert ids == {"1", "2"}
-    attr2 = next(a for a in result if a["id"] == "2")
-    assert attr2["waitTime"] == 5
-    assert attr2["status"] == "OPERATING"
-    assert attr2["lastUpdatedTs"] == "new2"
+    assert len(result) == 1
+    assert result[0]["id"] == "1"
+    assert result[0]["waitTime"] == 15
+
+
+def test_merge_live_data_preserves_wait_time_when_omitted():
+    """A CLOSED update omits waitTime; the last known value must survive."""
+    existing = [{
+        "id": "1",
+        "waitTime": 25,
+        "status": "OPERATING",
+        "down_since": "",
+        "lastUpdatedTs": "old",
+    }]
+    new_live = [{"id": "1", "status": "CLOSED", "lastUpdatedTs": "new"}]
+    result = merge_live_data(copy.deepcopy(existing), new_live)
+    assert result[0]["status"] == "CLOSED"
+    assert result[0]["waitTime"] == 25
+    assert result[0]["lastUpdatedTs"] == "new"
+
+
+def test_update_parks_live_data_fetch_failure_keeps_data_and_flags_stale(monkeypatch):
+    """A failed park fetch (429/timeout) must keep existing data and set live_data_stale."""
+    async def failing_fetch(park):
+        return None
+
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", failing_fetch)
+    parks_copy = copy.deepcopy(DUMMY_PARKS)
+    updated = update_parks_live_data(parks_copy)
+    attr = updated[0]["attractions"][0]
+    assert attr["waitTime"] == 10
+    assert attr["lastUpdatedTs"] == "old"
+    assert updated[0]["live_data_stale"] is True
+
+
+def test_update_parks_live_data_success_clears_stale_flag(monkeypatch):
+    async def ok_fetch(park):
+        return [{"id": "1", "waitTime": 12, "status": "OPERATING", "lastUpdatedTs": "new"}]
+
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", ok_fetch)
+    parks_copy = copy.deepcopy(DUMMY_PARKS)
+    parks_copy[0]["live_data_stale"] = True
+    updated = update_parks_live_data(parks_copy)
+    assert updated[0]["live_data_stale"] is False
+    assert updated[0]["attractions"][0]["waitTime"] == 12
 
 
 # --- Additional Tests to Increase Coverage ---
@@ -207,7 +247,7 @@ def test_update_parks_live_data_no_change(monkeypatch):
     async def dummy_fetch_live_data(attractions):
         return dummy_live_data
 
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch_live_data)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", dummy_fetch_live_data)
 
     parks_copy = copy.deepcopy(DUMMY_PARKS)
     updated_parks = update_parks_live_data(parks_copy)
@@ -262,7 +302,7 @@ def test_update_parks_live_data_multiple_attractions(monkeypatch):
     async def dummy_fetch_live_data(attractions):
         return dummy_live_data
 
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch_live_data)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", dummy_fetch_live_data)
 
     parks_copy = copy.deepcopy(parks)
     updated_parks = update_parks_live_data(parks_copy)
@@ -304,7 +344,7 @@ def test_update_parks_live_data_websocket_skips_http_fetch(monkeypatch):
         called.append(True)
         return []
 
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", should_not_be_called)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", should_not_be_called)
 
     parks_copy = copy.deepcopy(DUMMY_PARKS)
     update_parks_live_data(parks_copy, use_websocket=True)
@@ -316,11 +356,11 @@ def test_update_parks_live_data_no_websocket_calls_http_fetch(monkeypatch):
     """When use_websocket=False (default), fetch_live_data must be called."""
     called = []
 
-    async def dummy_fetch_live_data(attractions):
+    async def dummy_fetch_live_data(park):
         called.append(True)
-        return attractions
+        return []
 
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch_live_data)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", dummy_fetch_live_data)
 
     parks_copy = copy.deepcopy(DUMMY_PARKS)
     update_parks_live_data(parks_copy, use_websocket=False)
@@ -336,11 +376,11 @@ def test_live_data_updater_websocket_does_initial_fetch_then_skips_polling(monke
     parks_data = []
     fetch_call_count = []
 
-    async def counting_fetch(attractions):
+    async def counting_fetch(park):
         fetch_call_count.append(1)
-        return attractions
+        return []
 
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", counting_fetch)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", counting_fetch)
     monkeypatch.setattr("updater.data_updater.fetch_parks_and_attractions", lambda parks: copy.deepcopy(DUMMY_PARKS))
     monkeypatch.setattr("updater.data_updater.update_parks_operating_status", lambda parks: parks)
 
@@ -378,14 +418,14 @@ def test_live_data_updater_websocket_loop_updates_operating_status(monkeypatch):
     parks_data = []
     status_calls = []
 
-    async def dummy_fetch(attractions):
-        return attractions
+    async def dummy_fetch(park):
+        return []
 
     def recording_update(parks, fetch_schedules=True):
         status_calls.append(fetch_schedules)
         return parks
 
-    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch)
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", dummy_fetch)
     monkeypatch.setattr("updater.data_updater.fetch_parks_and_attractions", lambda parks: copy.deepcopy(DUMMY_PARKS))
     monkeypatch.setattr("updater.data_updater.update_parks_operating_status", recording_update)
 

--- a/tests/updater/test_data_updater.py
+++ b/tests/updater/test_data_updater.py
@@ -367,3 +367,42 @@ def test_live_data_updater_websocket_does_initial_fetch_then_skips_polling(monke
     # fetch_live_data called exactly once (initial fetch), not again in the loop
     assert len(fetch_call_count) == 1, "fetch_live_data should be called once for the initial fetch"
     assert loop_iterations == [1], "polling loop should have run once then stopped"
+
+
+def test_live_data_updater_websocket_loop_updates_operating_status(monkeypatch):
+    """
+    In websocket mode the polling loop must still call update_parks_operating_status
+    (with schedule fetching enabled) so schedule refreshes deferred by the WS thread
+    via 'schedule_refresh_needed' get serviced.
+    """
+    parks_data = []
+    status_calls = []
+
+    async def dummy_fetch(attractions):
+        return attractions
+
+    def recording_update(parks, fetch_schedules=True):
+        status_calls.append(fetch_schedules)
+        return parks
+
+    monkeypatch.setattr("updater.data_updater.fetch_live_data", dummy_fetch)
+    monkeypatch.setattr("updater.data_updater.fetch_parks_and_attractions", lambda parks: copy.deepcopy(DUMMY_PARKS))
+    monkeypatch.setattr("updater.data_updater.update_parks_operating_status", recording_update)
+
+    def fake_sleep(duration):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr("updater.data_updater.time", type("t", (), {"sleep": fake_sleep}))
+
+    updater_thread = threading.Thread(
+        target=live_data_updater,
+        args=(copy.deepcopy(DUMMY_PARKS), 0, parks_data),
+        kwargs={"use_websocket": True},
+        daemon=True,
+    )
+    updater_thread.start()
+    updater_thread.join(timeout=2)
+
+    # One call from the initial fetch, one from the loop iteration — both with
+    # schedule fetching enabled (the REST thread is where blocking HTTP belongs).
+    assert status_calls == [True, True]

--- a/tests/updater/test_websocket_updater.py
+++ b/tests/updater/test_websocket_updater.py
@@ -9,8 +9,11 @@ from updater.websocket_updater import (
     _RECONNECT_DELAY_MAX,
     _WS_HEARTBEAT_SECS,
     _WS_RECEIVE_TIMEOUT_SECS,
+    _WsStats,
     _apply_live_update,
     _next_delay,
+    _should_force_reconnect,
+    _watchdog,
     _ws_loop,
 )
 
@@ -201,6 +204,162 @@ def test_no_queue_data_sets_wait_none():
     with patch("updater.websocket_updater.update_parks_operating_status"):
         _apply_live_update(msg, parks)
     assert parks[0]["attractions"][0]["waitTime"] is None
+
+
+# --- event timestamps ---
+
+def test_event_timestamp_used_when_present():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={
+        "status": "OPERATING",
+        "lastUpdated": "2026-07-19T18:00:00Z",
+        "queue": {"STANDBY": {"waitTime": 10}},
+    })
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["lastUpdatedTs"] == "2026-07-19T18:00:00Z"
+
+
+def test_down_since_uses_event_timestamp():
+    """A DOWN event replayed after a reconnect carries the real outage start —
+    the display should show 'Down 30', not 'Down 0'."""
+    from datetime import datetime, timezone, timedelta
+    went_down = (datetime.now(timezone.utc) - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    parks = _parks_with_attr({"status": "OPERATING", "down_since": ""})
+    msg = _make_livedata_msg(data={"status": "DOWN", "lastUpdated": went_down})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    attr = parks[0]["attractions"][0]
+    assert attr["down_since"] == went_down
+    minutes = int(attr["waitTime"].split(" ")[1])
+    assert 28 <= minutes <= 32
+
+
+# --- watchdog ---
+
+def test_should_force_reconnect_silent_and_operating():
+    assert _should_force_reconnect(0, [{"operating": True}]) is True
+
+
+def test_should_force_reconnect_tolerates_overnight_silence():
+    assert _should_force_reconnect(0, [{"operating": False}, {"operating": False}]) is False
+
+
+def test_should_force_reconnect_not_when_messages_flow():
+    assert _should_force_reconnect(12, [{"operating": True}]) is False
+
+
+def test_should_force_reconnect_empty_parks():
+    assert _should_force_reconnect(0, []) is False
+
+
+def test_ws_stats_snapshot_resets_counter():
+    stats = _WsStats()
+    stats.note_message()
+    stats.note_message()
+    count, elapsed = stats.snapshot_and_reset()
+    assert count == 2
+    assert elapsed >= 0
+    count2, _ = stats.snapshot_and_reset()
+    assert count2 == 0
+
+
+class _WatchdogFakeWS:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+def test_watchdog_forces_reconnect_when_silent_while_operating():
+    ws = _WatchdogFakeWS()
+
+    async def instant_sleep(_delay):
+        pass
+
+    with patch("updater.websocket_updater.asyncio.sleep", instant_sleep):
+        asyncio.run(_watchdog(ws, _WsStats(), [{"operating": True}]))
+    assert ws.closed is True
+
+
+def test_watchdog_does_not_reconnect_while_messages_flow():
+    ws = _WatchdogFakeWS()
+    stats = _WsStats()
+    sleeps = []
+
+    async def traffic_then_stop(_delay):
+        sleeps.append(1)
+        if len(sleeps) >= 3:
+            raise asyncio.CancelledError
+        stats.note_message()  # traffic arrives during each window
+
+    with patch("updater.websocket_updater.asyncio.sleep", traffic_then_stop):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_watchdog(ws, stats, [{"operating": True}]))
+    assert ws.closed is False
+
+
+def test_watchdog_tolerates_silence_when_parks_closed():
+    ws = _WatchdogFakeWS()
+    sleeps = []
+
+    async def two_windows(_delay):
+        sleeps.append(1)
+        if len(sleeps) >= 2:
+            raise asyncio.CancelledError
+
+    with patch("updater.websocket_updater.asyncio.sleep", two_windows):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_watchdog(ws, _WsStats(), [{"operating": False}]))
+    assert ws.closed is False
+
+
+def test_ws_loop_cancels_watchdog_on_disconnect():
+    started = []
+    cancelled = []
+    real_sleep = asyncio.sleep
+
+    async def parked_watchdog(ws, stats, parks):
+        started.append(True)
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    captured = {}
+    parks = [{"id": "park-1", "name": "MK", "destination_id": "dest-1", "attractions": []}]
+
+    async def fake_sleep(delay):
+        # The reconnect backoff sleep ends the test; zero-delay yields run for real
+        # so the watchdog task gets scheduled before the receive loop finishes.
+        if delay:
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    class _YieldingWS(_FakeWS):
+        def __init__(self):
+            self._yielded = False
+
+        async def __anext__(self):
+            if not self._yielded:
+                self._yielded = True
+                await real_sleep(0)  # let the watchdog task start
+            raise StopAsyncIteration
+
+    class _YieldingSession(_FakeSession):
+        def ws_connect(self, url, **kwargs):
+            return _YieldingWS()
+
+    with patch("updater.websocket_updater.aiohttp.ClientSession", lambda: _YieldingSession(captured)), \
+         patch("updater.websocket_updater._watchdog", parked_watchdog), \
+         patch("updater.websocket_updater.asyncio.sleep", fake_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_ws_loop("dummy-key", parks))
+
+    assert started == [True]
+    assert cancelled == [True]
 
 
 # --- reconnect backoff ---

--- a/tests/updater/test_websocket_updater.py
+++ b/tests/updater/test_websocket_updater.py
@@ -134,6 +134,32 @@ def test_down_status_preserves_existing_down_since():
     assert parks[0]["attractions"][0]["down_since"] == "2026-01-01T00:00:00Z"
 
 
+def test_down_wait_time_uses_down_since_not_current_time():
+    """down_since set 30 min ago — waitTime should reflect ~30 min, not 0."""
+    from datetime import datetime, timezone, timedelta
+    down_since = (datetime.now(timezone.utc) - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    parks = _parks_with_attr({"status": "DOWN", "down_since": down_since})
+    msg = _make_livedata_msg(data={"status": "DOWN", "queue": {"STANDBY": {"waitTime": None}}})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    wait = parks[0]["attractions"][0]["waitTime"]
+    assert wait.startswith("Down ")
+    minutes = int(wait.split(" ")[1])
+    assert 28 <= minutes <= 32  # allow a couple seconds of drift
+
+
+def test_down_wait_time_is_zero_on_first_down_message():
+    """Ride just went down — down_since not set yet, so elapsed time should be ~0."""
+    parks = _parks_with_attr({"status": "OPERATING", "down_since": ""})
+    msg = _make_livedata_msg(data={"status": "DOWN", "queue": {"STANDBY": {"waitTime": None}}})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    wait = parks[0]["attractions"][0]["waitTime"]
+    assert wait.startswith("Down ")
+    minutes = int(wait.split(" ")[1])
+    assert 0 <= minutes <= 1
+
+
 # --- boarding group ---
 
 def test_boarding_group_range():

--- a/tests/updater/test_websocket_updater.py
+++ b/tests/updater/test_websocket_updater.py
@@ -1,0 +1,176 @@
+import copy
+from unittest.mock import patch
+
+from updater.websocket_updater import _apply_live_update
+
+DUMMY_ATTRACTION = {
+    "id": "attr-1",
+    "name": "Space Mountain",
+    "waitTime": 20,
+    "status": "OPERATING",
+    "lastUpdatedTs": "old",
+    "down_since": "",
+}
+
+DUMMY_PARKS = [{
+    "id": "park-1",
+    "name": "Magic Kingdom",
+    "attractions": [copy.deepcopy(DUMMY_ATTRACTION)],
+}]
+
+
+def _parks_with_attr(attr_override=None):
+    attr = copy.deepcopy(DUMMY_ATTRACTION)
+    if attr_override:
+        attr.update(attr_override)
+    return [{"id": "park-1", "name": "Magic Kingdom", "attractions": [attr]}]
+
+
+def _make_livedata_msg(entity_id="attr-1", entity_type="ATTRACTION", data=None):
+    return {
+        "event": "livedata",
+        "entityId": entity_id,
+        "entityType": entity_type,
+        "data": data or {"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 30}}},
+    }
+
+
+# --- event filtering ---
+
+def test_ignores_non_livedata_event():
+    parks = _parks_with_attr()
+    _apply_live_update({"event": "heartbeat"}, parks)
+    assert parks[0]["attractions"][0]["lastUpdatedTs"] == "old"
+
+
+def test_ignores_unknown_entity_type():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(entity_type="RESTAURANT")
+    _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["lastUpdatedTs"] == "old"
+
+
+def test_accepts_show_entity_type():
+    parks = [{"id": "park-1", "name": "MK", "attractions": [{
+        "id": "show-1", "name": "Festival of Fantasy", "waitTime": None,
+        "status": "OPERATING", "lastUpdatedTs": "old", "down_since": "",
+    }]}]
+    msg = {
+        "event": "livedata",
+        "entityId": "show-1",
+        "entityType": "SHOW",
+        "data": {"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 0}}},
+    }
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["lastUpdatedTs"] != "old"
+
+
+def test_subscribed_event_does_not_raise():
+    parks = _parks_with_attr()
+    _apply_live_update({"event": "subscribed", "entityId": "dest-1"}, parks)
+    assert parks[0]["attractions"][0]["lastUpdatedTs"] == "old"
+
+
+# --- operating status update gating ---
+
+def test_operating_status_updated_on_status_change():
+    parks = _parks_with_attr({"status": "DOWN"})
+    msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 10}}})
+    with patch("updater.websocket_updater.update_parks_operating_status") as mock_update:
+        _apply_live_update(msg, parks)
+    mock_update.assert_called_once_with([parks[0]])
+
+
+def test_operating_status_not_updated_when_status_unchanged():
+    parks = _parks_with_attr({"status": "OPERATING"})
+    msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 99}}})
+    with patch("updater.websocket_updater.update_parks_operating_status") as mock_update:
+        _apply_live_update(msg, parks)
+    mock_update.assert_not_called()
+
+
+# --- OPERATING update ---
+
+def test_operating_update_sets_wait_time_and_timestamp():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 45}}})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    attr = parks[0]["attractions"][0]
+    assert attr["waitTime"] == 45
+    assert attr["status"] == "OPERATING"
+    assert attr["down_since"] == ""
+    assert attr["lastUpdatedTs"] != "old"
+
+
+def test_timestamp_is_utc_iso_string():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 10}}})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    ts = parks[0]["attractions"][0]["lastUpdatedTs"]
+    assert ts.endswith("Z")
+    assert "T" in ts
+
+
+# --- DOWN status ---
+
+def test_down_status_sets_down_since():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={"status": "DOWN", "queue": {"STANDBY": {"waitTime": None}}})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    attr = parks[0]["attractions"][0]
+    assert attr["status"] == "DOWN"
+    assert attr["down_since"] != ""
+
+
+def test_down_status_preserves_existing_down_since():
+    parks = _parks_with_attr({"status": "DOWN", "down_since": "2026-01-01T00:00:00Z"})
+    msg = _make_livedata_msg(data={"status": "DOWN", "queue": {"STANDBY": {"waitTime": None}}})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["down_since"] == "2026-01-01T00:00:00Z"
+
+
+# --- boarding group ---
+
+def test_boarding_group_range():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={
+        "status": "OPERATING",
+        "queue": {"BOARDING_GROUP": {"currentGroupStart": 1, "currentGroupEnd": 50}},
+    })
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["waitTime"] == "Groups 1-50"
+
+
+def test_boarding_group_open_ended():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={
+        "status": "OPERATING",
+        "queue": {"BOARDING_GROUP": {"currentGroupStart": 10, "currentGroupEnd": None}},
+    })
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["waitTime"] == "Group 10+"
+
+
+def test_no_queue_data_sets_wait_none():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {}})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["waitTime"] is None
+
+
+# --- no match ---
+
+def test_unknown_entity_id_is_ignored():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(entity_id="unknown-id")
+    _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["waitTime"] == 20
+    assert parks[0]["attractions"][0]["lastUpdatedTs"] == "old"

--- a/tests/updater/test_websocket_updater.py
+++ b/tests/updater/test_websocket_updater.py
@@ -206,6 +206,38 @@ def test_no_queue_data_sets_wait_none():
     assert parks[0]["attractions"][0]["waitTime"] is None
 
 
+# --- thread safety ---
+
+class _SpyLock:
+    def __init__(self):
+        self.acquisitions = 0
+
+    def __enter__(self):
+        self.acquisitions += 1
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_apply_live_update_holds_parks_data_lock():
+    spy = _SpyLock()
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 30}}})
+    with patch("updater.websocket_updater.parks_data_lock", spy), \
+         patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert spy.acquisitions == 1
+
+
+def test_apply_live_update_skips_lock_for_non_livedata_events():
+    spy = _SpyLock()
+    parks = _parks_with_attr()
+    with patch("updater.websocket_updater.parks_data_lock", spy):
+        _apply_live_update({"event": "heartbeat"}, parks)
+    assert spy.acquisitions == 0
+
+
 # --- event timestamps ---
 
 def test_event_timestamp_used_when_present():

--- a/tests/updater/test_websocket_updater.py
+++ b/tests/updater/test_websocket_updater.py
@@ -1,7 +1,18 @@
+import asyncio
 import copy
 from unittest.mock import patch
 
-from updater.websocket_updater import _apply_live_update
+import pytest
+
+from updater.websocket_updater import (
+    _RECONNECT_DELAY_INITIAL,
+    _RECONNECT_DELAY_MAX,
+    _WS_HEARTBEAT_SECS,
+    _WS_RECEIVE_TIMEOUT_SECS,
+    _apply_live_update,
+    _next_delay,
+    _ws_loop,
+)
 
 DUMMY_ATTRACTION = {
     "id": "attr-1",
@@ -79,7 +90,7 @@ def test_operating_status_updated_on_status_change():
     msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 10}}})
     with patch("updater.websocket_updater.update_parks_operating_status") as mock_update:
         _apply_live_update(msg, parks)
-    mock_update.assert_called_once_with([parks[0]])
+    mock_update.assert_called_once_with([parks[0]], fetch_schedules=False)
 
 
 def test_operating_status_not_updated_when_status_unchanged():
@@ -190,6 +201,85 @@ def test_no_queue_data_sets_wait_none():
     with patch("updater.websocket_updater.update_parks_operating_status"):
         _apply_live_update(msg, parks)
     assert parks[0]["attractions"][0]["waitTime"] is None
+
+
+# --- reconnect backoff ---
+
+def test_next_delay_resets_after_stable_connection():
+    assert _next_delay(40, 3600) == _RECONNECT_DELAY_INITIAL
+    assert _next_delay(40, 60) == _RECONNECT_DELAY_INITIAL
+
+
+def test_next_delay_doubles_after_quick_death():
+    assert _next_delay(5, 2) == 10
+    assert _next_delay(10, 2) == 20
+
+
+def test_next_delay_doubles_when_never_connected():
+    assert _next_delay(5, None) == 10
+
+
+def test_next_delay_caps_at_max():
+    assert _next_delay(40, 1) == _RECONNECT_DELAY_MAX
+    assert _next_delay(_RECONNECT_DELAY_MAX, None) == _RECONNECT_DELAY_MAX
+
+
+# --- connection settings ---
+
+class _FakeWS:
+    """Minimal stand-in for aiohttp's ClientWebSocketResponse: connects,
+    accepts subscriptions, yields no messages, then closes."""
+
+    close_code = 1000
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    async def send_json(self, payload):
+        pass
+
+    def exception(self):
+        return None
+
+
+class _FakeSession:
+    def __init__(self, captured):
+        self._captured = captured
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def ws_connect(self, url, **kwargs):
+        self._captured.update(kwargs, url=url)
+        return _FakeWS()
+
+
+def test_ws_loop_connects_with_heartbeat_and_receive_timeout():
+    captured = {}
+    parks = [{"id": "park-1", "name": "MK", "destination_id": "dest-1", "attractions": []}]
+
+    async def cancel_sleep(_delay):
+        raise asyncio.CancelledError
+
+    with patch("updater.websocket_updater.aiohttp.ClientSession", lambda: _FakeSession(captured)), \
+         patch("updater.websocket_updater.asyncio.sleep", cancel_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_ws_loop("dummy-key", parks))
+
+    assert captured["heartbeat"] == _WS_HEARTBEAT_SECS
+    assert captured["receive_timeout"] == _WS_RECEIVE_TIMEOUT_SECS
 
 
 # --- no match ---

--- a/updater/data_updater.py
+++ b/updater/data_updater.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 import traceback
 
-from api.disney_api import fetch_parks_and_attractions, fetch_live_data, update_parks_operating_status
+from api.disney_api import fetch_parks_and_attractions, fetch_park_live_data, update_parks_operating_status
 from api.weather import fetch_weather_data
 from utils import debug
 from utils.utils import get_eastern
@@ -18,12 +18,13 @@ def merge_live_data(existing_attractions, new_live_data):
         attr_id = new_attr.get("id")
 
         if attr_id in attraction_map:
-            # Merge the new live data fields into the existing attraction.
+            # Merge only the fields present in the update; a CLOSED/REFURBISHMENT
+            # update omits waitTime so the last known value is preserved.
             existing = attraction_map[attr_id]
             existing.update({
-                "waitTime": new_attr.get("waitTime"),
-                "status": new_attr.get("status"),
-                "lastUpdatedTs": new_attr.get("lastUpdatedTs")
+                key: new_attr[key]
+                for key in ("waitTime", "status", "lastUpdatedTs")
+                if key in new_attr
             })
 
             # Do not overwrite down_since if already set, unless status is no longer DOWN.
@@ -35,9 +36,9 @@ def merge_live_data(existing_attractions, new_live_data):
                     existing["down_since"] = new_attr.get("lastUpdatedTs")
                     debug.info(f"DOWN (REST): {existing.get('name')} — down_since set to {existing['down_since']}")
         else:
-            # If new attraction is not present in the existing map, add it.
-            attraction_map[attr_id] = new_attr
-            debug.info(f"Adding new attraction {attr_id}: {new_attr}")
+            # Unknown ids are skipped: live updates carry no name/entityType, and
+            # roster changes are handled by refresh_park_attractions.
+            debug.log(f"Ignoring live data for unknown attraction id {attr_id}")
     return list(attraction_map.values())
 
 
@@ -48,8 +49,15 @@ def update_parks_live_data(parks, use_websocket=False):
     """
     for park in parks:
         if not use_websocket and park.get("attractions"):
-            new_live_data = asyncio.run(fetch_live_data(park["attractions"]))
-            park["attractions"] = merge_live_data(park["attractions"], new_live_data)
+            new_live_data = asyncio.run(fetch_park_live_data(park))
+            if new_live_data is None:
+                # Fetch failed (rate limit, timeout, bad response): keep existing
+                # data and flag it stale so the next cycle is a retry, not a skip.
+                park["live_data_stale"] = True
+                debug.warning(f"Live data fetch failed for {park.get('name')}; keeping existing data.")
+            else:
+                park["live_data_stale"] = False
+                park["attractions"] = merge_live_data(park["attractions"], new_live_data)
 
         if park.get("location") and park.get("operating"):
             park["weather"] = fetch_weather_data(park.get("location").get("latitude"), park.get("location").get("longitude"))

--- a/updater/data_updater.py
+++ b/updater/data_updater.py
@@ -76,8 +76,9 @@ def live_data_updater(disney_park_list, update_interval, parks_data, use_websock
         try:
             if parks_data:
                 updated_parks = update_parks_live_data(parks_data, use_websocket=use_websocket)
-                if not use_websocket:
-                    updated_parks = update_parks_operating_status(updated_parks)
+                # Runs in websocket mode too: the WS thread defers schedule
+                # fetches (schedule_refresh_needed) to this thread.
+                updated_parks = update_parks_operating_status(updated_parks)
                 parks_data[:] = updated_parks
                 if use_websocket:
                     debug.info("REST loop (websocket_only mode): weather refreshed, attraction polling skipped.")

--- a/updater/data_updater.py
+++ b/updater/data_updater.py
@@ -13,7 +13,7 @@ def merge_live_data(existing_attractions, new_live_data):
 
     # Create a mapping from attraction id to the existing attraction object.
     attraction_map = {attr["id"]: attr for attr in existing_attractions}
-    debug.info(f"Starting to update new live data for attractions.")
+    debug.log(f"Starting to update new live data for attractions.")
     for new_attr in new_live_data:
         attr_id = new_attr.get("id")
 
@@ -40,19 +40,16 @@ def merge_live_data(existing_attractions, new_live_data):
     return list(attraction_map.values())
 
 
-def update_parks_live_data(parks):
+def update_parks_live_data(parks, use_websocket=False):
     """
     For each park in parks, update live data for attractions.
-    If the park is not operating, update the schedule for the next day.
-    If the park is operating, do not update the schedule.
+    If use_websocket is True, skip HTTP live data fetching — the WS handles it.
     """
     for park in parks:
-        # Fetch live data for the current attractions.
-        if park.get("attractions"):
+        if not use_websocket and park.get("attractions"):
             new_live_data = asyncio.run(fetch_live_data(park["attractions"]))
             park["attractions"] = merge_live_data(park["attractions"], new_live_data)
 
-        # Update weather data
         if park.get("location") and park.get("operating"):
             park["weather"] = fetch_weather_data(park.get("location").get("latitude"), park.get("location").get("longitude"))
 
@@ -60,22 +57,27 @@ def update_parks_live_data(parks):
     return parks
 
 
-def live_data_updater(disney_park_list, update_interval, parks_data):
+def live_data_updater(disney_park_list, update_interval, parks_data, use_websocket=False):
     """
     Background thread that updates live data for parks every 'update_interval' seconds.
-    The initial fetch of parks is done only once, and then live data is updated on the existing parks.
+    When use_websocket is True, skips HTTP live data polling — the WS thread handles that.
+    Always performs an initial REST live data fetch so attractions have data before WS catches up.
     """
-    # Initial fetch of parks and attractions.
     parks_data[:] = fetch_parks_and_attractions(disney_park_list)
+    if use_websocket:
+        debug.info("WebSocket mode: performing initial REST live data fetch, then handing off to WS.")
+        initial_parks = update_parks_live_data(list(parks_data), use_websocket=False)
+        initial_parks = update_parks_operating_status(initial_parks)
+        parks_data[:] = initial_parks
+        debug.info("Initial REST live data fetch complete — WebSocket will handle updates from here.")
     while True:
         try:
             if parks_data:
-                # Only update live data for existing parks.
-                updated_parks = update_parks_live_data(parks_data)
-                # Update each park with operating status.
-                updated_parks = update_parks_operating_status(updated_parks)
-                parks_data[:] = updated_parks  # Update shared list in-place.
-                debug.info("Parks live data updated in background.")
+                updated_parks = update_parks_live_data(parks_data, use_websocket=use_websocket)
+                if not use_websocket:
+                    updated_parks = update_parks_operating_status(updated_parks)
+                parks_data[:] = updated_parks
+                debug.info("Parks data updated in background.")
             else:
                 debug.warning("No parks found during live data update.")
         except Exception as e:

--- a/updater/data_updater.py
+++ b/updater/data_updater.py
@@ -4,12 +4,18 @@ import traceback
 
 from api.disney_api import fetch_parks_and_attractions, fetch_park_live_data, update_parks_operating_status
 from api.weather import fetch_weather_data
+from updater.shared import parks_data_lock
 from utils import debug
 from utils.utils import get_eastern
 
 
 def merge_live_data(existing_attractions, new_live_data):
-    """ Update existing attractions with new live data. Preserve the 'down_since' field if it already exists. """
+    """
+    Update existing attractions in place with new live data. Preserve the
+    'down_since' field if it already exists. Returns the same list object —
+    rebuilding the list would silently drop concurrent WS-thread updates to
+    the dicts it contains.
+    """
 
     # Create a mapping from attraction id to the existing attraction object.
     attraction_map = {attr["id"]: attr for attr in existing_attractions}
@@ -39,7 +45,7 @@ def merge_live_data(existing_attractions, new_live_data):
             # Unknown ids are skipped: live updates carry no name/entityType, and
             # roster changes are handled by refresh_park_attractions.
             debug.log(f"Ignoring live data for unknown attraction id {attr_id}")
-    return list(attraction_map.values())
+    return existing_attractions
 
 
 def update_parks_live_data(parks, use_websocket=False):
@@ -56,8 +62,9 @@ def update_parks_live_data(parks, use_websocket=False):
                 park["live_data_stale"] = True
                 debug.warning(f"Live data fetch failed for {park.get('name')}; keeping existing data.")
             else:
-                park["live_data_stale"] = False
-                park["attractions"] = merge_live_data(park["attractions"], new_live_data)
+                with parks_data_lock:
+                    park["live_data_stale"] = False
+                    merge_live_data(park["attractions"], new_live_data)
 
         if park.get("location") and park.get("operating"):
             park["weather"] = fetch_weather_data(park.get("location").get("latitude"), park.get("location").get("longitude"))
@@ -78,7 +85,8 @@ def live_data_updater(disney_park_list, update_interval, parks_data, use_websock
         debug.info("WebSocket mode: performing initial REST live data fetch, then handing off to WS.")
         initial_parks = update_parks_live_data(list(parks_data), use_websocket=False)
         initial_parks = update_parks_operating_status(initial_parks)
-        parks_data[:] = initial_parks
+        with parks_data_lock:
+            parks_data[:] = initial_parks
         debug.info("Initial REST live data fetch complete — WebSocket will handle attraction updates.")
     while True:
         try:
@@ -87,7 +95,8 @@ def live_data_updater(disney_park_list, update_interval, parks_data, use_websock
                 # Runs in websocket mode too: the WS thread defers schedule
                 # fetches (schedule_refresh_needed) to this thread.
                 updated_parks = update_parks_operating_status(updated_parks)
-                parks_data[:] = updated_parks
+                with parks_data_lock:
+                    parks_data[:] = updated_parks
                 if use_websocket:
                     debug.info("REST loop (websocket_only mode): weather refreshed, attraction polling skipped.")
                 else:

--- a/updater/data_updater.py
+++ b/updater/data_updater.py
@@ -33,6 +33,7 @@ def merge_live_data(existing_attractions, new_live_data):
                 # If it's still DOWN and down_since is not set, set it now.
                 if not existing.get("down_since"):
                     existing["down_since"] = new_attr.get("lastUpdatedTs")
+                    debug.info(f"DOWN (REST): {existing.get('name')} — down_since set to {existing['down_since']}")
         else:
             # If new attraction is not present in the existing map, add it.
             attraction_map[attr_id] = new_attr
@@ -60,7 +61,8 @@ def update_parks_live_data(parks, use_websocket=False):
 def live_data_updater(disney_park_list, update_interval, parks_data, use_websocket=False):
     """
     Background thread that updates live data for parks every 'update_interval' seconds.
-    When use_websocket is True, skips HTTP live data polling — the WS thread handles that.
+    When use_websocket is True, skips HTTP live data polling — the WS thread handles that —
+    but continues to poll weather every update_interval seconds.
     Always performs an initial REST live data fetch so attractions have data before WS catches up.
     """
     parks_data[:] = fetch_parks_and_attractions(disney_park_list)
@@ -69,7 +71,7 @@ def live_data_updater(disney_park_list, update_interval, parks_data, use_websock
         initial_parks = update_parks_live_data(list(parks_data), use_websocket=False)
         initial_parks = update_parks_operating_status(initial_parks)
         parks_data[:] = initial_parks
-        debug.info("Initial REST live data fetch complete — WebSocket will handle updates from here.")
+        debug.info("Initial REST live data fetch complete — WebSocket will handle attraction updates.")
     while True:
         try:
             if parks_data:
@@ -77,7 +79,19 @@ def live_data_updater(disney_park_list, update_interval, parks_data, use_websock
                 if not use_websocket:
                     updated_parks = update_parks_operating_status(updated_parks)
                 parks_data[:] = updated_parks
-                debug.info("Parks data updated in background.")
+                if use_websocket:
+                    debug.info("REST loop (websocket_only mode): weather refreshed, attraction polling skipped.")
+                else:
+                    for park in updated_parks:
+                        attrs = park.get("attractions") or []
+                        total = len(attrs)
+                        down = [a for a in attrs if a.get("status") == "DOWN"]
+                        operating = [a for a in attrs if a.get("status") == "OPERATING"]
+                        debug.info(
+                            f"REST poll [{park['name']}]: {len(operating)} operating, "
+                            f"{len(down)} DOWN, {total} total"
+                            + (f" | DOWN: {', '.join(a['name'] for a in down)}" if down else "")
+                        )
             else:
                 debug.warning("No parks found during live data update.")
         except Exception as e:

--- a/updater/shared.py
+++ b/updater/shared.py
@@ -1,0 +1,7 @@
+import threading
+
+# Guards mutations of the shared parks_data structure by the WebSocket and REST
+# threads. Held only for in-memory writes (microseconds) — never across HTTP
+# calls. The display thread deliberately reads without locking: a torn read
+# costs one frame of slightly inconsistent pixels, not corrupted state.
+parks_data_lock = threading.Lock()

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -15,6 +15,17 @@ from utils import debug
 WS_URL = "wss://ws.themeparks.wiki/v1/live"
 _RECONNECT_DELAY_INITIAL = 5
 _RECONNECT_DELAY_MAX = 60
+_WS_HEARTBEAT_SECS = 30
+_WS_RECEIVE_TIMEOUT_SECS = 120
+_STABLE_CONNECTION_SECS = 60
+
+
+def _next_delay(current_delay, connection_duration):
+    """Reset backoff only after a stable connection; otherwise keep doubling so a
+    connect-then-immediately-die loop can't hammer the server every 5s."""
+    if connection_duration is not None and connection_duration >= _STABLE_CONNECTION_SECS:
+        return _RECONNECT_DELAY_INITIAL
+    return min(max(current_delay, _RECONNECT_DELAY_INITIAL) * 2, _RECONNECT_DELAY_MAX)
 
 # Rolling message counter for heartbeat diagnostics
 _ws_msg_count = 0
@@ -99,7 +110,9 @@ def _apply_live_update(data, parks_data):
                     f"WS update: {attr['name']} ({park['name']}) "
                     f"{prev_status} → {status}, wait={attr.get('waitTime')}"
                 )
-                update_parks_operating_status([park])
+                # fetch_schedules=False: we're on the WS event loop — schedule
+                # fetching is blocking HTTP and is deferred to the REST thread.
+                update_parks_operating_status([park], fetch_schedules=False)
             return
 
 
@@ -109,22 +122,29 @@ async def _ws_loop(api_key, parks_data):
     is_reconnect = False
 
     while True:
+        connected_at = None
         try:
             headers = {"X-API-Key": api_key}
             async with aiohttp.ClientSession() as session:
-                async with session.ws_connect(WS_URL, headers=headers, ssl=ssl_ctx) as ws:
+                async with session.ws_connect(
+                    WS_URL,
+                    headers=headers,
+                    ssl=ssl_ctx,
+                    heartbeat=_WS_HEARTBEAT_SECS,
+                    receive_timeout=_WS_RECEIVE_TIMEOUT_SECS,
+                ) as ws:
+                    connected_at = time.monotonic()
                     if is_reconnect:
                         debug.info("WebSocket reconnected — refreshing live data via REST.")
                         for park in parks_data:
                             if park.get("attractions"):
                                 new_live_data = await fetch_live_data(park["attractions"])
                                 park["attractions"] = merge_live_data(park["attractions"], new_live_data)
-                        updated = update_parks_operating_status(list(parks_data))
+                        updated = update_parks_operating_status(list(parks_data), fetch_schedules=False)
                         parks_data[:] = updated
                         debug.info("REST refresh after reconnect complete.")
                     else:
                         debug.info("WebSocket connected to ThemeParks.wiki")
-                    delay = _RECONNECT_DELAY_INITIAL
                     is_reconnect = True
 
                     destination_ids = list({
@@ -150,17 +170,25 @@ async def _ws_loop(api_key, parks_data):
                                 _apply_live_update(json.loads(msg.data), parks_data)
                             except json.JSONDecodeError:
                                 debug.warning(f"Non-JSON WS message: {msg.data}")
-                        elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
-                            debug.warning(f"WebSocket closed/error: {ws.exception()}")
+                        elif msg.type == aiohttp.WSMsgType.ERROR:
+                            debug.warning(f"WebSocket error message: {ws.exception()}")
                             break
+
+                    # aiohttp ends the async-for on close rather than yielding
+                    # a CLOSED message; surface why the connection ended.
+                    debug.warning(
+                        f"WebSocket receive loop ended: close_code={ws.close_code}, "
+                        f"exception={ws.exception()}"
+                    )
 
         except Exception as e:
             debug.error(f"WebSocket error: {e}\n{traceback.format_exc()}")
 
         _log_ws_heartbeat(force=True)
+        duration = (time.monotonic() - connected_at) if connected_at is not None else None
+        delay = _next_delay(delay, duration)
         debug.info(f"WebSocket disconnected; reconnecting in {delay}s")
         await asyncio.sleep(delay)
-        delay = min(delay * 2, _RECONNECT_DELAY_MAX)
 
 
 def websocket_live_updater(api_key, parks_data):

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -16,9 +16,31 @@ WS_URL = "wss://ws.themeparks.wiki/v1/live"
 _RECONNECT_DELAY_INITIAL = 5
 _RECONNECT_DELAY_MAX = 60
 
+# Rolling message counter for heartbeat diagnostics
+_ws_msg_count = 0
+_ws_last_heartbeat = None
+
+
+def _log_ws_heartbeat(force=False):
+    """Log a periodic WS health summary every 5 minutes."""
+    global _ws_msg_count, _ws_last_heartbeat
+    now = datetime.now(timezone.utc)
+    if _ws_last_heartbeat is None:
+        _ws_last_heartbeat = now
+    elapsed = (now - _ws_last_heartbeat).total_seconds()
+    if force or elapsed >= 300:
+        debug.info(
+            f"WS heartbeat: {_ws_msg_count} messages received in last "
+            f"{int(elapsed)}s (since {_ws_last_heartbeat.strftime('%H:%M:%S')} UTC)"
+        )
+        _ws_msg_count = 0
+        _ws_last_heartbeat = now
+
 
 def _apply_live_update(data, parks_data):
     """Apply a single WebSocket live-data event to the shared parks_data list."""
+    global _ws_msg_count
+    _ws_msg_count += 1
     event = data.get("event")
     debug.log(f"WS message: {data}")
 
@@ -50,6 +72,7 @@ def _apply_live_update(data, parks_data):
             if status == "DOWN":
                 if not attr.get("down_since"):
                     attr["down_since"] = last_updated
+                    debug.info(f"DOWN (WS): {attr['name']} ({park['name']}) — down_since set to {last_updated}")
                 down_time = get_down_time(attr["down_since"])
                 attr["waitTime"] = f"Down {down_time}" if down_time is not None else "Down"
             elif status in ("CLOSED", "REFURBISHMENT"):
@@ -120,6 +143,7 @@ async def _ws_loop(api_key, parks_data):
                     debug.info(f"Subscribed to destinations: {destination_ids}")
 
                     async for msg in ws:
+                        _log_ws_heartbeat()
                         if msg.type == aiohttp.WSMsgType.TEXT:
                             debug.log(f"WS raw: {msg.data}")
                             try:
@@ -133,6 +157,7 @@ async def _ws_loop(api_key, parks_data):
         except Exception as e:
             debug.error(f"WebSocket error: {e}\n{traceback.format_exc()}")
 
+        _log_ws_heartbeat(force=True)
         debug.info(f"WebSocket disconnected; reconnecting in {delay}s")
         await asyncio.sleep(delay)
         delay = min(delay * 2, _RECONNECT_DELAY_MAX)

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -1,0 +1,151 @@
+import asyncio
+import json
+import ssl
+import time
+import traceback
+from datetime import datetime, timezone
+
+import aiohttp
+import certifi
+
+from api.disney_api import get_down_time, update_parks_operating_status
+from updater.data_updater import update_parks_live_data
+from utils import debug
+
+WS_URL = "wss://ws.themeparks.wiki/v1/live"
+_RECONNECT_DELAY_INITIAL = 5
+_RECONNECT_DELAY_MAX = 60
+
+
+def _apply_live_update(data, parks_data):
+    """Apply a single WebSocket live-data event to the shared parks_data list."""
+    event = data.get("event")
+    debug.log(f"WS message: {data}")
+
+    if event == "subscribed":
+        debug.info(f"WebSocket subscribed to: {data.get('name') or data.get('entityId')}")
+        return
+
+    if event != "livedata":
+        return
+
+    entity_type = data.get("entityType")
+    if entity_type not in ("ATTRACTION", "SHOW"):
+        return
+
+    entity_id = data.get("entityId")
+    live = data.get("data") or {}
+    status = live.get("status")
+    last_updated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for park in parks_data:
+        for attr in park.get("attractions", []):
+            if attr.get("id") != entity_id:
+                continue
+
+            prev_status = attr.get("status")
+            attr["status"] = status
+            attr["lastUpdatedTs"] = last_updated
+
+            if status == "DOWN":
+                attr["waitTime"] = f"Down {get_down_time(last_updated)}" if last_updated else "Down"
+                if not attr.get("down_since"):
+                    attr["down_since"] = last_updated
+            elif status in ("CLOSED", "REFURBISHMENT"):
+                attr["down_since"] = ""
+            else:
+                attr["down_since"] = ""
+                queue = live.get("queue", {})
+                standby = queue.get("STANDBY", {}).get("waitTime")
+                if standby is not None:
+                    attr["waitTime"] = standby
+                else:
+                    bg = queue.get("BOARDING_GROUP", {})
+                    start = bg.get("currentGroupStart")
+                    end = bg.get("currentGroupEnd")
+                    if start is not None and end is not None:
+                        attr["waitTime"] = f"Groups {start}-{end}"
+                    elif start is not None:
+                        attr["waitTime"] = f"Group {start}+"
+                    else:
+                        attr["waitTime"] = None
+
+            if prev_status != status:
+                debug.info(
+                    f"WS update: {attr['name']} ({park['name']}) "
+                    f"{prev_status} → {status}, wait={attr.get('waitTime')}"
+                )
+                update_parks_operating_status([park])
+            return
+
+
+async def _ws_loop(api_key, parks_data):
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    delay = _RECONNECT_DELAY_INITIAL
+    is_reconnect = False
+
+    while True:
+        try:
+            headers = {"X-API-Key": api_key}
+            async with aiohttp.ClientSession() as session:
+                async with session.ws_connect(WS_URL, headers=headers, ssl=ssl_ctx) as ws:
+                    if is_reconnect:
+                        debug.info("WebSocket reconnected — refreshing live data via REST.")
+                        updated = update_parks_live_data(list(parks_data), use_websocket=False)
+                        updated = update_parks_operating_status(updated)
+                        parks_data[:] = updated
+                        debug.info("REST refresh after reconnect complete.")
+                    else:
+                        debug.info("WebSocket connected to ThemeParks.wiki")
+                    delay = _RECONNECT_DELAY_INITIAL
+                    is_reconnect = True
+
+                    destination_ids = list({
+                        p["destination_id"] for p in parks_data
+                        if p.get("destination_id")
+                    })
+                    if not destination_ids:
+                        debug.warning("No destination IDs in parks_data; will retry")
+                        break
+
+                    for dest_id in destination_ids:
+                        await ws.send_json({
+                            "event": "subscribe",
+                            "entityId": dest_id,
+                        })
+                    debug.info(f"Subscribed to destinations: {destination_ids}")
+
+                    async for msg in ws:
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            debug.log(f"WS raw: {msg.data}")
+                            try:
+                                _apply_live_update(json.loads(msg.data), parks_data)
+                            except json.JSONDecodeError:
+                                debug.warning(f"Non-JSON WS message: {msg.data}")
+                        elif msg.type in (aiohttp.WSMsgType.ERROR, aiohttp.WSMsgType.CLOSED):
+                            debug.warning(f"WebSocket closed/error: {ws.exception()}")
+                            break
+
+        except Exception as e:
+            debug.error(f"WebSocket error: {e}\n{traceback.format_exc()}")
+
+        debug.info(f"WebSocket disconnected; reconnecting in {delay}s")
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, _RECONNECT_DELAY_MAX)
+
+
+def websocket_live_updater(api_key, parks_data):
+    """
+    Background thread entry point. Waits for parks_data to be populated, then
+    maintains a persistent WebSocket connection for real-time attraction updates.
+    Falls back gracefully if the connection cannot be established.
+    """
+    while not parks_data:
+        time.sleep(1)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(_ws_loop(api_key, parks_data))
+    finally:
+        loop.close()

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -10,6 +10,7 @@ import certifi
 
 from api.disney_api import fetch_park_live_data, get_down_time, parse_queue_wait, update_parks_operating_status
 from updater.data_updater import merge_live_data
+from updater.shared import parks_data_lock
 from utils import debug
 
 WS_URL = "wss://ws.themeparks.wiki/v1/live"
@@ -91,36 +92,37 @@ def _apply_live_update(data, parks_data):
     # malformed message (down_since and staleness math depend on this).
     last_updated = live.get("lastUpdated") or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    for park in parks_data:
-        for attr in park.get("attractions", []):
-            if attr.get("id") != entity_id:
-                continue
+    with parks_data_lock:
+        for park in parks_data:
+            for attr in park.get("attractions", []):
+                if attr.get("id") != entity_id:
+                    continue
 
-            prev_status = attr.get("status")
-            attr["status"] = status
-            attr["lastUpdatedTs"] = last_updated
+                prev_status = attr.get("status")
+                attr["status"] = status
+                attr["lastUpdatedTs"] = last_updated
 
-            if status == "DOWN":
-                if not attr.get("down_since"):
-                    attr["down_since"] = last_updated
-                    debug.info(f"DOWN (WS): {attr['name']} ({park['name']}) — down_since set to {last_updated}")
-                down_time = get_down_time(attr["down_since"])
-                attr["waitTime"] = f"Down {down_time}" if down_time is not None else "Down"
-            elif status in ("CLOSED", "REFURBISHMENT"):
-                attr["down_since"] = ""
-            else:
-                attr["down_since"] = ""
-                attr["waitTime"] = parse_queue_wait(live.get("queue") or {})
+                if status == "DOWN":
+                    if not attr.get("down_since"):
+                        attr["down_since"] = last_updated
+                        debug.info(f"DOWN (WS): {attr['name']} ({park['name']}) — down_since set to {last_updated}")
+                    down_time = get_down_time(attr["down_since"])
+                    attr["waitTime"] = f"Down {down_time}" if down_time is not None else "Down"
+                elif status in ("CLOSED", "REFURBISHMENT"):
+                    attr["down_since"] = ""
+                else:
+                    attr["down_since"] = ""
+                    attr["waitTime"] = parse_queue_wait(live.get("queue") or {})
 
-            if prev_status != status:
-                debug.info(
-                    f"WS update: {attr['name']} ({park['name']}) "
-                    f"{prev_status} → {status}, wait={attr.get('waitTime')}"
-                )
-                # fetch_schedules=False: we're on the WS event loop — schedule
-                # fetching is blocking HTTP and is deferred to the REST thread.
-                update_parks_operating_status([park], fetch_schedules=False)
-            return
+                if prev_status != status:
+                    debug.info(
+                        f"WS update: {attr['name']} ({park['name']}) "
+                        f"{prev_status} → {status}, wait={attr.get('waitTime')}"
+                    )
+                    # fetch_schedules=False: we're on the WS event loop — schedule
+                    # fetching is blocking HTTP and is deferred to the REST thread.
+                    update_parks_operating_status([park], fetch_schedules=False)
+                return
 
 
 async def _ws_loop(api_key, parks_data):
@@ -153,10 +155,10 @@ async def _ws_loop(api_key, parks_data):
                                         "keeping existing data."
                                     )
                                 else:
-                                    park["live_data_stale"] = False
-                                    park["attractions"] = merge_live_data(park["attractions"], new_live_data)
-                        updated = update_parks_operating_status(list(parks_data), fetch_schedules=False)
-                        parks_data[:] = updated
+                                    with parks_data_lock:
+                                        park["live_data_stale"] = False
+                                        merge_live_data(park["attractions"], new_live_data)
+                        update_parks_operating_status(list(parks_data), fetch_schedules=False)
                         debug.info("REST refresh after reconnect complete.")
                     else:
                         debug.info("WebSocket connected to ThemeParks.wiki")

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -27,31 +27,49 @@ def _next_delay(current_delay, connection_duration):
         return _RECONNECT_DELAY_INITIAL
     return min(max(current_delay, _RECONNECT_DELAY_INITIAL) * 2, _RECONNECT_DELAY_MAX)
 
-# Rolling message counter for heartbeat diagnostics
-_ws_msg_count = 0
-_ws_last_heartbeat = None
+_WATCHDOG_INTERVAL_SECS = 300
 
 
-def _log_ws_heartbeat(force=False):
-    """Log a periodic WS health summary every 5 minutes."""
-    global _ws_msg_count, _ws_last_heartbeat
-    now = datetime.now(timezone.utc)
-    if _ws_last_heartbeat is None:
-        _ws_last_heartbeat = now
-    elapsed = (now - _ws_last_heartbeat).total_seconds()
-    if force or elapsed >= 300:
-        debug.info(
-            f"WS heartbeat: {_ws_msg_count} messages received in last "
-            f"{int(elapsed)}s (since {_ws_last_heartbeat.strftime('%H:%M:%S')} UTC)"
-        )
-        _ws_msg_count = 0
-        _ws_last_heartbeat = now
+class _WsStats:
+    """Per-connection message counter for the watchdog's health window."""
+
+    def __init__(self):
+        self.msg_count = 0
+        self.window_started = time.monotonic()
+
+    def note_message(self):
+        self.msg_count += 1
+
+    def snapshot_and_reset(self):
+        elapsed = time.monotonic() - self.window_started
+        count = self.msg_count
+        self.msg_count = 0
+        self.window_started = time.monotonic()
+        return count, elapsed
+
+
+def _should_force_reconnect(msg_count, parks_data):
+    """Silence is only suspicious while something is open and should be streaming."""
+    if msg_count > 0:
+        return False
+    return any(p.get("operating") for p in parks_data)
+
+
+async def _watchdog(ws, stats, parks_data):
+    """Log a periodic health summary and force a reconnect if the connection is
+    alive at the protocol level but no data flows while parks are operating."""
+    while True:
+        await asyncio.sleep(_WATCHDOG_INTERVAL_SECS)
+        count, elapsed = stats.snapshot_and_reset()
+        debug.info(f"WS heartbeat: {count} messages received in last {int(elapsed)}s")
+        if _should_force_reconnect(count, parks_data):
+            debug.warning("WS watchdog: no messages while parks operating — forcing reconnect.")
+            await ws.close()
+            return
 
 
 def _apply_live_update(data, parks_data):
     """Apply a single WebSocket live-data event to the shared parks_data list."""
-    global _ws_msg_count
-    _ws_msg_count += 1
     event = data.get("event")
     debug.log(f"WS message: {data}")
 
@@ -69,7 +87,9 @@ def _apply_live_update(data, parks_data):
     entity_id = data.get("entityId")
     live = data.get("data") or {}
     status = live.get("status")
-    last_updated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Prefer the server's event timestamp; fall back to receive time only for a
+    # malformed message (down_since and staleness math depend on this).
+    last_updated = live.get("lastUpdated") or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     for park in parks_data:
         for attr in park.get("attractions", []):
@@ -157,17 +177,24 @@ async def _ws_loop(api_key, parks_data):
                         })
                     debug.info(f"Subscribed to destinations: {destination_ids}")
 
-                    async for msg in ws:
-                        _log_ws_heartbeat()
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            debug.log(f"WS raw: {msg.data}")
-                            try:
-                                _apply_live_update(json.loads(msg.data), parks_data)
-                            except json.JSONDecodeError:
-                                debug.warning(f"Non-JSON WS message: {msg.data}")
-                        elif msg.type == aiohttp.WSMsgType.ERROR:
-                            debug.warning(f"WebSocket error message: {ws.exception()}")
-                            break
+                    stats = _WsStats()
+                    watchdog = asyncio.create_task(_watchdog(ws, stats, parks_data))
+                    try:
+                        async for msg in ws:
+                            stats.note_message()
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                debug.log(f"WS raw: {msg.data}")
+                                try:
+                                    _apply_live_update(json.loads(msg.data), parks_data)
+                                except json.JSONDecodeError:
+                                    debug.warning(f"Non-JSON WS message: {msg.data}")
+                            elif msg.type == aiohttp.WSMsgType.ERROR:
+                                debug.warning(f"WebSocket error message: {ws.exception()}")
+                                break
+                    finally:
+                        # Without this, every reconnect leaks a watchdog task
+                        # holding a reference to a dead connection.
+                        watchdog.cancel()
 
                     # aiohttp ends the async-for on close rather than yielding
                     # a CLOSED message; surface why the connection ended.
@@ -179,7 +206,6 @@ async def _ws_loop(api_key, parks_data):
         except Exception as e:
             debug.error(f"WebSocket error: {e}\n{traceback.format_exc()}")
 
-        _log_ws_heartbeat(force=True)
         duration = (time.monotonic() - connected_at) if connected_at is not None else None
         delay = _next_delay(delay, duration)
         debug.info(f"WebSocket disconnected; reconnecting in {delay}s")

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -8,8 +8,8 @@ from datetime import datetime, timezone
 import aiohttp
 import certifi
 
-from api.disney_api import get_down_time, update_parks_operating_status
-from updater.data_updater import update_parks_live_data
+from api.disney_api import fetch_live_data, get_down_time, update_parks_operating_status
+from updater.data_updater import merge_live_data
 from utils import debug
 
 WS_URL = "wss://ws.themeparks.wiki/v1/live"
@@ -91,8 +91,11 @@ async def _ws_loop(api_key, parks_data):
                 async with session.ws_connect(WS_URL, headers=headers, ssl=ssl_ctx) as ws:
                     if is_reconnect:
                         debug.info("WebSocket reconnected — refreshing live data via REST.")
-                        updated = update_parks_live_data(list(parks_data), use_websocket=False)
-                        updated = update_parks_operating_status(updated)
+                        for park in parks_data:
+                            if park.get("attractions"):
+                                new_live_data = await fetch_live_data(park["attractions"])
+                                park["attractions"] = merge_live_data(park["attractions"], new_live_data)
+                        updated = update_parks_operating_status(list(parks_data))
                         parks_data[:] = updated
                         debug.info("REST refresh after reconnect complete.")
                     else:

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import aiohttp
 import certifi
 
-from api.disney_api import fetch_live_data, get_down_time, update_parks_operating_status
+from api.disney_api import fetch_park_live_data, get_down_time, parse_queue_wait, update_parks_operating_status
 from updater.data_updater import merge_live_data
 from utils import debug
 
@@ -90,20 +90,7 @@ def _apply_live_update(data, parks_data):
                 attr["down_since"] = ""
             else:
                 attr["down_since"] = ""
-                queue = live.get("queue", {})
-                standby = queue.get("STANDBY", {}).get("waitTime")
-                if standby is not None:
-                    attr["waitTime"] = standby
-                else:
-                    bg = queue.get("BOARDING_GROUP", {})
-                    start = bg.get("currentGroupStart")
-                    end = bg.get("currentGroupEnd")
-                    if start is not None and end is not None:
-                        attr["waitTime"] = f"Groups {start}-{end}"
-                    elif start is not None:
-                        attr["waitTime"] = f"Group {start}+"
-                    else:
-                        attr["waitTime"] = None
+                attr["waitTime"] = parse_queue_wait(live.get("queue") or {})
 
             if prev_status != status:
                 debug.info(
@@ -138,8 +125,16 @@ async def _ws_loop(api_key, parks_data):
                         debug.info("WebSocket reconnected — refreshing live data via REST.")
                         for park in parks_data:
                             if park.get("attractions"):
-                                new_live_data = await fetch_live_data(park["attractions"])
-                                park["attractions"] = merge_live_data(park["attractions"], new_live_data)
+                                new_live_data = await fetch_park_live_data(park)
+                                if new_live_data is None:
+                                    park["live_data_stale"] = True
+                                    debug.warning(
+                                        f"Live data refresh failed for {park.get('name')} after reconnect; "
+                                        "keeping existing data."
+                                    )
+                                else:
+                                    park["live_data_stale"] = False
+                                    park["attractions"] = merge_live_data(park["attractions"], new_live_data)
                         updated = update_parks_operating_status(list(parks_data), fetch_schedules=False)
                         parks_data[:] = updated
                         debug.info("REST refresh after reconnect complete.")

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -48,9 +48,10 @@ def _apply_live_update(data, parks_data):
             attr["lastUpdatedTs"] = last_updated
 
             if status == "DOWN":
-                attr["waitTime"] = f"Down {get_down_time(last_updated)}" if last_updated else "Down"
                 if not attr.get("down_since"):
                     attr["down_since"] = last_updated
+                down_time = get_down_time(attr["down_since"])
+                attr["waitTime"] = f"Down {down_time}" if down_time is not None else "Down"
             elif status in ("CLOSED", "REFURBISHMENT"):
                 attr["down_since"] = ""
             else:

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -7,8 +7,9 @@ logger = logging.getLogger("disney-lll")
 # Determine the base directory path dynamically
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Define the logs directory path
-LOG_DIR = os.path.join(BASE_DIR, 'logs')
+# Define the logs directory path. Tests override this (LLL_LOG_DIR) so pytest
+# runs never interleave with a live app's real logs/app.log.
+LOG_DIR = os.environ.get('LLL_LOG_DIR') or os.path.join(BASE_DIR, 'logs')
 
 # Ensure the directory exists
 if not os.path.exists(LOG_DIR):


### PR DESCRIPTION
## Summary

- **WebSocket live updates**: When a ThemeParks API key is configured, live wait times are delivered via a persistent WebSocket connection (`wss://ws.themeparks.wiki/v1/live`). The app performs an initial REST fetch at startup to populate all attraction data, then hands off to the WebSocket for real-time updates. On reconnect, a full REST refresh is triggered to catch any missed changes.
- **Polling fallback**: Without an API key, the app continues to poll the REST API every 5 minutes.
- **Multi-park support**: Parks are now resolved by name from config, supporting any ThemeParks Wiki destination (Cedar Point, Kings Island, etc.). `destination_id` is included in park data for WebSocket subscription.
- **Display & logging cleanup**: Fixed `loop_through_attractions` so "Displaying ride" is only logged for rides actually shown. Demoted noisy per-attraction REST fetch logs from INFO to debug. `update_parks_operating_status` is now only called when an attraction's status actually changes, and only for the affected park.
- **Trip countdown**: Supports multiple upcoming trip dates with a week-after display window.
- **README updated** with WebSocket setup, park configuration, and API key instructions.

## Test plan

- [ ] Run `pytest` — all tests pass
- [ ] Run in emulator mode: `./disney.py --emulated --led-cols=64 --led-rows=32`
- [ ] Confirm WebSocket connects and logs "WebSocket connected to ThemeParks.wiki"
- [ ] Confirm initial REST fetch populates all attractions before WS takes over
- [ ] Confirm only operating attractions with wait times are displayed and logged
- [ ] Confirm fallback polling works when no `themeparks_api_key` is set
- [ ] Pull branch on Pi and run with hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)