### PR TITLE
WebSocket staleness watchdog + event-time timestamps

### DIFF
--- a/tests/updater/test_websocket_updater.py
+++ b/tests/updater/test_websocket_updater.py
@@ -9,8 +9,11 @@ from updater.websocket_updater import (
     _RECONNECT_DELAY_MAX,
     _WS_HEARTBEAT_SECS,
     _WS_RECEIVE_TIMEOUT_SECS,
+    _WsStats,
     _apply_live_update,
     _next_delay,
+    _should_force_reconnect,
+    _watchdog,
     _ws_loop,
 )
 
@@ -201,6 +204,162 @@ def test_no_queue_data_sets_wait_none():
     with patch("updater.websocket_updater.update_parks_operating_status"):
         _apply_live_update(msg, parks)
     assert parks[0]["attractions"][0]["waitTime"] is None
+
+
+# --- event timestamps ---
+
+def test_event_timestamp_used_when_present():
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={
+        "status": "OPERATING",
+        "lastUpdated": "2026-07-19T18:00:00Z",
+        "queue": {"STANDBY": {"waitTime": 10}},
+    })
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert parks[0]["attractions"][0]["lastUpdatedTs"] == "2026-07-19T18:00:00Z"
+
+
+def test_down_since_uses_event_timestamp():
+    """A DOWN event replayed after a reconnect carries the real outage start —
+    the display should show 'Down 30', not 'Down 0'."""
+    from datetime import datetime, timezone, timedelta
+    went_down = (datetime.now(timezone.utc) - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    parks = _parks_with_attr({"status": "OPERATING", "down_since": ""})
+    msg = _make_livedata_msg(data={"status": "DOWN", "lastUpdated": went_down})
+    with patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    attr = parks[0]["attractions"][0]
+    assert attr["down_since"] == went_down
+    minutes = int(attr["waitTime"].split(" ")[1])
+    assert 28 <= minutes <= 32
+
+
+# --- watchdog ---
+
+def test_should_force_reconnect_silent_and_operating():
+    assert _should_force_reconnect(0, [{"operating": True}]) is True
+
+
+def test_should_force_reconnect_tolerates_overnight_silence():
+    assert _should_force_reconnect(0, [{"operating": False}, {"operating": False}]) is False
+
+
+def test_should_force_reconnect_not_when_messages_flow():
+    assert _should_force_reconnect(12, [{"operating": True}]) is False
+
+
+def test_should_force_reconnect_empty_parks():
+    assert _should_force_reconnect(0, []) is False
+
+
+def test_ws_stats_snapshot_resets_counter():
+    stats = _WsStats()
+    stats.note_message()
+    stats.note_message()
+    count, elapsed = stats.snapshot_and_reset()
+    assert count == 2
+    assert elapsed >= 0
+    count2, _ = stats.snapshot_and_reset()
+    assert count2 == 0
+
+
+class _WatchdogFakeWS:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+def test_watchdog_forces_reconnect_when_silent_while_operating():
+    ws = _WatchdogFakeWS()
+
+    async def instant_sleep(_delay):
+        pass
+
+    with patch("updater.websocket_updater.asyncio.sleep", instant_sleep):
+        asyncio.run(_watchdog(ws, _WsStats(), [{"operating": True}]))
+    assert ws.closed is True
+
+
+def test_watchdog_does_not_reconnect_while_messages_flow():
+    ws = _WatchdogFakeWS()
+    stats = _WsStats()
+    sleeps = []
+
+    async def traffic_then_stop(_delay):
+        sleeps.append(1)
+        if len(sleeps) >= 3:
+            raise asyncio.CancelledError
+        stats.note_message()  # traffic arrives during each window
+
+    with patch("updater.websocket_updater.asyncio.sleep", traffic_then_stop):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_watchdog(ws, stats, [{"operating": True}]))
+    assert ws.closed is False
+
+
+def test_watchdog_tolerates_silence_when_parks_closed():
+    ws = _WatchdogFakeWS()
+    sleeps = []
+
+    async def two_windows(_delay):
+        sleeps.append(1)
+        if len(sleeps) >= 2:
+            raise asyncio.CancelledError
+
+    with patch("updater.websocket_updater.asyncio.sleep", two_windows):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_watchdog(ws, _WsStats(), [{"operating": False}]))
+    assert ws.closed is False
+
+
+def test_ws_loop_cancels_watchdog_on_disconnect():
+    started = []
+    cancelled = []
+    real_sleep = asyncio.sleep
+
+    async def parked_watchdog(ws, stats, parks):
+        started.append(True)
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    captured = {}
+    parks = [{"id": "park-1", "name": "MK", "destination_id": "dest-1", "attractions": []}]
+
+    async def fake_sleep(delay):
+        # The reconnect backoff sleep ends the test; zero-delay yields run for real
+        # so the watchdog task gets scheduled before the receive loop finishes.
+        if delay:
+            raise asyncio.CancelledError
+        await real_sleep(0)
+
+    class _YieldingWS(_FakeWS):
+        def __init__(self):
+            self._yielded = False
+
+        async def __anext__(self):
+            if not self._yielded:
+                self._yielded = True
+                await real_sleep(0)  # let the watchdog task start
+            raise StopAsyncIteration
+
+    class _YieldingSession(_FakeSession):
+        def ws_connect(self, url, **kwargs):
+            return _YieldingWS()
+
+    with patch("updater.websocket_updater.aiohttp.ClientSession", lambda: _YieldingSession(captured)), \
+         patch("updater.websocket_updater._watchdog", parked_watchdog), \
+         patch("updater.websocket_updater.asyncio.sleep", fake_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(_ws_loop("dummy-key", parks))
+
+    assert started == [True]
+    assert cancelled == [True]
 
 
 # --- reconnect backoff ---

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -27,31 +27,49 @@ def _next_delay(current_delay, connection_duration):
         return _RECONNECT_DELAY_INITIAL
     return min(max(current_delay, _RECONNECT_DELAY_INITIAL) * 2, _RECONNECT_DELAY_MAX)
 
-# Rolling message counter for heartbeat diagnostics
-_ws_msg_count = 0
-_ws_last_heartbeat = None
+_WATCHDOG_INTERVAL_SECS = 300
 
 
-def _log_ws_heartbeat(force=False):
-    """Log a periodic WS health summary every 5 minutes."""
-    global _ws_msg_count, _ws_last_heartbeat
-    now = datetime.now(timezone.utc)
-    if _ws_last_heartbeat is None:
-        _ws_last_heartbeat = now
-    elapsed = (now - _ws_last_heartbeat).total_seconds()
-    if force or elapsed >= 300:
-        debug.info(
-            f"WS heartbeat: {_ws_msg_count} messages received in last "
-            f"{int(elapsed)}s (since {_ws_last_heartbeat.strftime('%H:%M:%S')} UTC)"
-        )
-        _ws_msg_count = 0
-        _ws_last_heartbeat = now
+class _WsStats:
+    """Per-connection message counter for the watchdog's health window."""
+
+    def __init__(self):
+        self.msg_count = 0
+        self.window_started = time.monotonic()
+
+    def note_message(self):
+        self.msg_count += 1
+
+    def snapshot_and_reset(self):
+        elapsed = time.monotonic() - self.window_started
+        count = self.msg_count
+        self.msg_count = 0
+        self.window_started = time.monotonic()
+        return count, elapsed
+
+
+def _should_force_reconnect(msg_count, parks_data):
+    """Silence is only suspicious while something is open and should be streaming."""
+    if msg_count > 0:
+        return False
+    return any(p.get("operating") for p in parks_data)
+
+
+async def _watchdog(ws, stats, parks_data):
+    """Log a periodic health summary and force a reconnect if the connection is
+    alive at the protocol level but no data flows while parks are operating."""
+    while True:
+        await asyncio.sleep(_WATCHDOG_INTERVAL_SECS)
+        count, elapsed = stats.snapshot_and_reset()
+        debug.info(f"WS heartbeat: {count} messages received in last {int(elapsed)}s")
+        if _should_force_reconnect(count, parks_data):
+            debug.warning("WS watchdog: no messages while parks operating — forcing reconnect.")
+            await ws.close()
+            return
 
 
 def _apply_live_update(data, parks_data):
     """Apply a single WebSocket live-data event to the shared parks_data list."""
-    global _ws_msg_count
-    _ws_msg_count += 1
     event = data.get("event")
     debug.log(f"WS message: {data}")
 
@@ -69,7 +87,9 @@ def _apply_live_update(data, parks_data):
     entity_id = data.get("entityId")
     live = data.get("data") or {}
     status = live.get("status")
-    last_updated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # Prefer the server's event timestamp; fall back to receive time only for a
+    # malformed message (down_since and staleness math depend on this).
+    last_updated = live.get("lastUpdated") or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     for park in parks_data:
         for attr in park.get("attractions", []):
@@ -157,17 +177,24 @@ async def _ws_loop(api_key, parks_data):
                         })
                     debug.info(f"Subscribed to destinations: {destination_ids}")
 
-                    async for msg in ws:
-                        _log_ws_heartbeat()
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            debug.log(f"WS raw: {msg.data}")
-                            try:
-                                _apply_live_update(json.loads(msg.data), parks_data)
-                            except json.JSONDecodeError:
-                                debug.warning(f"Non-JSON WS message: {msg.data}")
-                        elif msg.type == aiohttp.WSMsgType.ERROR:
-                            debug.warning(f"WebSocket error message: {ws.exception()}")
-                            break
+                    stats = _WsStats()
+                    watchdog = asyncio.create_task(_watchdog(ws, stats, parks_data))
+                    try:
+                        async for msg in ws:
+                            stats.note_message()
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                debug.log(f"WS raw: {msg.data}")
+                                try:
+                                    _apply_live_update(json.loads(msg.data), parks_data)
+                                except json.JSONDecodeError:
+                                    debug.warning(f"Non-JSON WS message: {msg.data}")
+                            elif msg.type == aiohttp.WSMsgType.ERROR:
+                                debug.warning(f"WebSocket error message: {ws.exception()}")
+                                break
+                    finally:
+                        # Without this, every reconnect leaks a watchdog task
+                        # holding a reference to a dead connection.
+                        watchdog.cancel()
 
                     # aiohttp ends the async-for on close rather than yielding
                     # a CLOSED message; surface why the connection ended.
@@ -179,7 +206,6 @@ async def _ws_loop(api_key, parks_data):
         except Exception as e:
             debug.error(f"WebSocket error: {e}\n{traceback.format_exc()}")
 
-        _log_ws_heartbeat(force=True)
         duration = (time.monotonic() - connected_at) if connected_at is not None else None
         delay = _next_delay(delay, duration)
         debug.info(f"WebSocket disconnected; reconnecting in {delay}s")


### PR DESCRIPTION
## Summary

Stacked on #73 (which stacks on #72). Third layer of the WS resilience work: detects the failure mode aiohttp pings cannot — a connection that is alive at the protocol level but silently delivers no data (the throttled/stopped-stream case).

### Watchdog
- New `_watchdog` task per connection: every 300s it logs a health summary (`WS heartbeat: N messages in last Xs`) **regardless of traffic** — the old `_log_ws_heartbeat` only executed when a message arrived, so it was silent during exactly the stall it existed to report.
- Decision logic is a pure function: zero messages in a window **while any park is `operating`** → `await ws.close()`, which ends the receive loop and drops into the existing reconnect + cheap per-park REST refresh (#73). Overnight silence with all parks closed is tolerated.
- The watchdog is cancelled in a `finally` when the receive loop ends, so flaky nights don't accumulate leaked tasks holding dead connections.
- Worst-case degraded behavior if the server keeps accepting connections but never sends data: one reconnect + ~6-request refresh every ~5 minutes, so the board stays populated from REST.

### Honest timestamps
- `_apply_live_update` now stamps `lastUpdatedTs` and `down_since` from the event's server-side `lastUpdated` (verified present on all 229 ATTRACTION/SHOW entries across MK, Cedar Point, and Kings Island; receive-time fallback kept for malformed messages).
- User-visible fix: a DOWN event replayed after a reconnect now shows the real outage duration ("Down 30") instead of restarting at "Down 0".

## Testing
- 176 tests pass (11 new): decision-function cases (silent+operating / overnight / traffic / no parks), stats window reset, watchdog close/no-close behavior, watchdog cancellation on disconnect, event-timestamp propagation, and the replayed-DOWN regression.
- Emulator smoke run: connects, subscribes to all 3 destinations; initial REST fetch now ~2s (was ~17s pre-#73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)