### PR TITLE
Thread-safe parks_data: in-place merge + write lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,17 +29,26 @@ pipreqs . --force
 
 ## Architecture
 
-The application is a continuous display loop that fetches Disney World attraction wait times and renders them on an RGB LED matrix. Two threads run concurrently:
+The application is a continuous display loop that fetches Disney World attraction wait times and renders them on an RGB LED matrix. Two or three threads run concurrently:
 
 - **Main thread** (`disney.py`): Drives the display loop — renders Mickey logo → optional trip countdown → park title screen → attraction wait times, cycling indefinitely.
-- **Background thread** (`updater/data_updater.py:live_data_updater`): Fetches updated live wait times every 5 minutes and updates the shared `parks_data` list in-place.
+- **REST thread** (`updater/data_updater.py:live_data_updater`): Fetches live wait times every `update_interval` seconds (5 min) and updates the shared `parks_data` list in-place. Always does the initial fetch/populate, even in WebSocket mode.
+- **WebSocket thread** (`updater/websocket_updater.py:websocket_live_updater`), started only when `config.json`'s `themeparks_api_key` is set or `websocket_only: true`: maintains a persistent connection to `wss://ws.themeparks.wiki/v1/live` for real-time attraction updates. When active, the REST thread skips attraction polling (`use_websocket=True`) but keeps refreshing weather and servicing deferred schedule fetches.
 
 ### Data flow
 
 1. `api/disney_api.py:fetch_list_of_disney_world_parks()` — fetches the 4 WDW theme parks (excluding water parks) from the ThemeParks Wiki API.
 2. `api/disney_api.py:fetch_parks_and_attractions()` — fetches each park's attraction list; initial wait times are empty placeholders.
-3. Background thread calls `fetch_live_data()` (async, via `aiohttp`) to concurrently fetch live wait times for all attractions, then `merge_live_data()` merges them into the shared list.
+3. Live wait times come from one `api/disney_api.py:fetch_park_live_data()` call per park (`/entity/{parkId}/live` — all children in one request, not one call per attraction), parsed by `build_live_updates()`/`parse_queue_wait()`, then merged into the shared list by `updater/data_updater.py:merge_live_data()`. In WebSocket mode, per-event updates arrive instead via `updater/websocket_updater.py:_apply_live_update()`, which reuses `parse_queue_wait()`; the per-park REST fetch still runs once at startup and after every WS reconnect.
 4. `api/weather.py` provides weather data per park, fetched via OpenWeatherMap (requires API key in `config.json`).
+
+### WebSocket resilience
+
+`updater/websocket_updater.py` maintains the live connection with several layered defenses (see git history on `feature/websocket` and its stack for the incident that motivated each):
+- `ws_connect(..., heartbeat=30, receive_timeout=120)` detects a dead socket and forces a reconnect within ~2 minutes.
+- A per-connection `_watchdog` task force-reconnects if zero messages arrive in a 5-minute window while any park is `operating` — catches a connection that's alive at the protocol level but has stopped streaming data.
+- Reconnect backoff (`_next_delay`) only resets to 5s after a connection stays up 60s+; otherwise it doubles (capped at 60s), so a connect-then-die loop can't hammer the server.
+- `attr["lastUpdatedTs"]`/`down_since` are stamped from the event's own `lastUpdated`, not receive time — confirmed present on all ATTRACTION/SHOW entries from the live API.
 
 ### Display layer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Tests use `pytest`. The `tests/stubs/conftest.py` patches `builtins.open` to int
 
 The `operating` field on a park dict is set by `update_parks_operating_status()` — a park is considered operating only if at least one attraction has a non-null wait time and `OPERATING` status. The main loop skips parks where `operating` is falsy. Its `fetch_schedules` flag controls whether a closed→open transition fetches the park schedule immediately (blocking HTTP) or only sets `schedule_refresh_needed`; the WebSocket thread always passes `fetch_schedules=False` (never block the asyncio event loop) and the REST thread services the flag on its next 5-minute cycle.
 
+Mutations of the shared `parks_data` structure (WS thread and REST thread) must hold `updater/shared.py:parks_data_lock` — but only for in-memory writes, never across HTTP calls. `merge_live_data` mutates attraction dicts in place and returns the same list; don't rebuild the list, that drops concurrent WS updates. The display thread reads without locking by design.
+
 ### Gotchas
 
 - The app must run from the repo root — font paths (`assets/fonts/...`) and `config.json`/`emulator_config.json` are resolved relative to the cwd.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LightningLane-Live-LED is a Python application designed to fetch and display wai
 - **API Integration:**  
   Retrieves park data and attraction details for Walt Disney World, Cedar Point, Kings Island, and any other destination supported by the ThemeParks Wiki API. Parks are configured by name in `config.json`.
 - **Real-Time WebSocket Updates:**  
-  When a ThemeParks API key is configured, live wait times are delivered via a persistent WebSocket connection (`wss://ws.themeparks.wiki/v1/live`) for instant updates as attraction statuses change. The app performs an initial REST fetch at startup to populate all data, then hands off to the WebSocket for ongoing updates. If the WebSocket disconnects and reconnects, a REST refresh is automatically triggered to catch any changes missed during the outage.
+  When a ThemeParks API key is configured (or `websocket_only` is enabled — see [below](#themeparks-api-key-recommended)), live wait times are delivered via a persistent WebSocket connection (`wss://ws.themeparks.wiki/v1/live`) for instant updates as attraction statuses change. The app performs an initial REST fetch at startup to populate all data, then hands off to the WebSocket for ongoing updates. The connection is self-healing: a dead or silently-stalled connection is detected and reconnected automatically (typically within 2 minutes), with a REST refresh triggered afterward to catch any changes missed during the outage.
 - **Polling Fallback:**  
   Without an API key, the app falls back to polling the REST API every 5 minutes for live wait times.
 - **Dynamic Display Rendering:**  
@@ -182,6 +182,24 @@ To enable real-time WebSocket updates, add a ThemeParks API key to `config.json`
 ```
 
 Without this key the app falls back to polling the REST API every 5 minutes. With it, attraction status changes appear on the display within seconds. You can request an API key from the [ThemeParks Wiki](https://api.themeparks.wiki).
+
+If you'd rather not use an API key, you can still enable WebSocket mode by setting `websocket_only` to `true` in `config.json`:
+
+```json
+"websocket_only": true
+```
+
+This connects to the same public WebSocket feed without sending an API key. Leave both `themeparks_api_key` unset (or set to the placeholder value) and `websocket_only: false` to use REST polling only.
+
+#### WebSocket Connection Health
+
+The WebSocket connection is monitored and self-healing:
+- A dead connection (network drop, server-side timeout) is detected within about 2 minutes and reconnected automatically.
+- A connection that stays open but silently stops delivering updates is detected by a background watchdog and force-reconnected, as long as at least one configured park is currently operating.
+- Every reconnect (whether from an error or the watchdog) triggers a REST refresh so the display catches up on anything missed during the outage.
+- Reconnect attempts back off (5s, 10s, 20s, ... up to 60s) if the connection keeps failing quickly, so a persistent outage doesn't hammer the API.
+
+You can watch this behavior in the logs (`logs/app.log`) — look for `WebSocket connected`, `WS heartbeat`, and `WebSocket disconnected; reconnecting in Ns` messages.
 
 ### Configuring Parks
 

--- a/tests/updater/test_data_updater.py
+++ b/tests/updater/test_data_updater.py
@@ -187,6 +187,48 @@ def test_merge_live_data_ignores_unknown_ids():
     assert result[0]["waitTime"] == 15
 
 
+def test_merge_live_data_mutates_in_place():
+    """merge must return the same list and same dict objects it was given —
+    rebuilding either would drop concurrent WS-thread updates."""
+    existing = [{
+        "id": "1",
+        "waitTime": 10,
+        "status": "OPERATING",
+        "down_since": "",
+        "lastUpdatedTs": "old",
+    }]
+    original_attr = existing[0]
+    result = merge_live_data(existing, [
+        {"id": "1", "waitTime": 15, "status": "OPERATING", "lastUpdatedTs": "new"},
+    ])
+    assert result is existing
+    assert result[0] is original_attr
+    assert original_attr["waitTime"] == 15
+
+
+class SpyLock:
+    def __init__(self):
+        self.acquisitions = 0
+
+    def __enter__(self):
+        self.acquisitions += 1
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_update_parks_live_data_merges_under_lock(monkeypatch):
+    async def ok_fetch(park):
+        return [{"id": "1", "waitTime": 12, "status": "OPERATING", "lastUpdatedTs": "new"}]
+
+    spy = SpyLock()
+    monkeypatch.setattr("updater.data_updater.fetch_park_live_data", ok_fetch)
+    monkeypatch.setattr("updater.data_updater.parks_data_lock", spy)
+    update_parks_live_data(copy.deepcopy(DUMMY_PARKS))
+    assert spy.acquisitions == 1
+
+
 def test_merge_live_data_preserves_wait_time_when_omitted():
     """A CLOSED update omits waitTime; the last known value must survive."""
     existing = [{

--- a/tests/updater/test_websocket_updater.py
+++ b/tests/updater/test_websocket_updater.py
@@ -206,6 +206,38 @@ def test_no_queue_data_sets_wait_none():
     assert parks[0]["attractions"][0]["waitTime"] is None
 
 
+# --- thread safety ---
+
+class _SpyLock:
+    def __init__(self):
+        self.acquisitions = 0
+
+    def __enter__(self):
+        self.acquisitions += 1
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_apply_live_update_holds_parks_data_lock():
+    spy = _SpyLock()
+    parks = _parks_with_attr()
+    msg = _make_livedata_msg(data={"status": "OPERATING", "queue": {"STANDBY": {"waitTime": 30}}})
+    with patch("updater.websocket_updater.parks_data_lock", spy), \
+         patch("updater.websocket_updater.update_parks_operating_status"):
+        _apply_live_update(msg, parks)
+    assert spy.acquisitions == 1
+
+
+def test_apply_live_update_skips_lock_for_non_livedata_events():
+    spy = _SpyLock()
+    parks = _parks_with_attr()
+    with patch("updater.websocket_updater.parks_data_lock", spy):
+        _apply_live_update({"event": "heartbeat"}, parks)
+    assert spy.acquisitions == 0
+
+
 # --- event timestamps ---
 
 def test_event_timestamp_used_when_present():

--- a/updater/data_updater.py
+++ b/updater/data_updater.py
@@ -4,12 +4,18 @@ import traceback
 
 from api.disney_api import fetch_parks_and_attractions, fetch_park_live_data, update_parks_operating_status
 from api.weather import fetch_weather_data
+from updater.shared import parks_data_lock
 from utils import debug
 from utils.utils import get_eastern
 
 
 def merge_live_data(existing_attractions, new_live_data):
-    """ Update existing attractions with new live data. Preserve the 'down_since' field if it already exists. """
+    """
+    Update existing attractions in place with new live data. Preserve the
+    'down_since' field if it already exists. Returns the same list object —
+    rebuilding the list would silently drop concurrent WS-thread updates to
+    the dicts it contains.
+    """
 
     # Create a mapping from attraction id to the existing attraction object.
     attraction_map = {attr["id"]: attr for attr in existing_attractions}
@@ -39,7 +45,7 @@ def merge_live_data(existing_attractions, new_live_data):
             # Unknown ids are skipped: live updates carry no name/entityType, and
             # roster changes are handled by refresh_park_attractions.
             debug.log(f"Ignoring live data for unknown attraction id {attr_id}")
-    return list(attraction_map.values())
+    return existing_attractions
 
 
 def update_parks_live_data(parks, use_websocket=False):
@@ -56,8 +62,9 @@ def update_parks_live_data(parks, use_websocket=False):
                 park["live_data_stale"] = True
                 debug.warning(f"Live data fetch failed for {park.get('name')}; keeping existing data.")
             else:
-                park["live_data_stale"] = False
-                park["attractions"] = merge_live_data(park["attractions"], new_live_data)
+                with parks_data_lock:
+                    park["live_data_stale"] = False
+                    merge_live_data(park["attractions"], new_live_data)
 
         if park.get("location") and park.get("operating"):
             park["weather"] = fetch_weather_data(park.get("location").get("latitude"), park.get("location").get("longitude"))
@@ -78,7 +85,8 @@ def live_data_updater(disney_park_list, update_interval, parks_data, use_websock
         debug.info("WebSocket mode: performing initial REST live data fetch, then handing off to WS.")
         initial_parks = update_parks_live_data(list(parks_data), use_websocket=False)
         initial_parks = update_parks_operating_status(initial_parks)
-        parks_data[:] = initial_parks
+        with parks_data_lock:
+            parks_data[:] = initial_parks
         debug.info("Initial REST live data fetch complete — WebSocket will handle attraction updates.")
     while True:
         try:
@@ -87,7 +95,8 @@ def live_data_updater(disney_park_list, update_interval, parks_data, use_websock
                 # Runs in websocket mode too: the WS thread defers schedule
                 # fetches (schedule_refresh_needed) to this thread.
                 updated_parks = update_parks_operating_status(updated_parks)
-                parks_data[:] = updated_parks
+                with parks_data_lock:
+                    parks_data[:] = updated_parks
                 if use_websocket:
                     debug.info("REST loop (websocket_only mode): weather refreshed, attraction polling skipped.")
                 else:

--- a/updater/shared.py
+++ b/updater/shared.py
@@ -1,0 +1,7 @@
+import threading
+
+# Guards mutations of the shared parks_data structure by the WebSocket and REST
+# threads. Held only for in-memory writes (microseconds) — never across HTTP
+# calls. The display thread deliberately reads without locking: a torn read
+# costs one frame of slightly inconsistent pixels, not corrupted state.
+parks_data_lock = threading.Lock()

--- a/updater/websocket_updater.py
+++ b/updater/websocket_updater.py
@@ -10,6 +10,7 @@ import certifi
 
 from api.disney_api import fetch_park_live_data, get_down_time, parse_queue_wait, update_parks_operating_status
 from updater.data_updater import merge_live_data
+from updater.shared import parks_data_lock
 from utils import debug
 
 WS_URL = "wss://ws.themeparks.wiki/v1/live"
@@ -91,36 +92,37 @@ def _apply_live_update(data, parks_data):
     # malformed message (down_since and staleness math depend on this).
     last_updated = live.get("lastUpdated") or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    for park in parks_data:
-        for attr in park.get("attractions", []):
-            if attr.get("id") != entity_id:
-                continue
+    with parks_data_lock:
+        for park in parks_data:
+            for attr in park.get("attractions", []):
+                if attr.get("id") != entity_id:
+                    continue
 
-            prev_status = attr.get("status")
-            attr["status"] = status
-            attr["lastUpdatedTs"] = last_updated
+                prev_status = attr.get("status")
+                attr["status"] = status
+                attr["lastUpdatedTs"] = last_updated
 
-            if status == "DOWN":
-                if not attr.get("down_since"):
-                    attr["down_since"] = last_updated
-                    debug.info(f"DOWN (WS): {attr['name']} ({park['name']}) — down_since set to {last_updated}")
-                down_time = get_down_time(attr["down_since"])
-                attr["waitTime"] = f"Down {down_time}" if down_time is not None else "Down"
-            elif status in ("CLOSED", "REFURBISHMENT"):
-                attr["down_since"] = ""
-            else:
-                attr["down_since"] = ""
-                attr["waitTime"] = parse_queue_wait(live.get("queue") or {})
+                if status == "DOWN":
+                    if not attr.get("down_since"):
+                        attr["down_since"] = last_updated
+                        debug.info(f"DOWN (WS): {attr['name']} ({park['name']}) — down_since set to {last_updated}")
+                    down_time = get_down_time(attr["down_since"])
+                    attr["waitTime"] = f"Down {down_time}" if down_time is not None else "Down"
+                elif status in ("CLOSED", "REFURBISHMENT"):
+                    attr["down_since"] = ""
+                else:
+                    attr["down_since"] = ""
+                    attr["waitTime"] = parse_queue_wait(live.get("queue") or {})
 
-            if prev_status != status:
-                debug.info(
-                    f"WS update: {attr['name']} ({park['name']}) "
-                    f"{prev_status} → {status}, wait={attr.get('waitTime')}"
-                )
-                # fetch_schedules=False: we're on the WS event loop — schedule
-                # fetching is blocking HTTP and is deferred to the REST thread.
-                update_parks_operating_status([park], fetch_schedules=False)
-            return
+                if prev_status != status:
+                    debug.info(
+                        f"WS update: {attr['name']} ({park['name']}) "
+                        f"{prev_status} → {status}, wait={attr.get('waitTime')}"
+                    )
+                    # fetch_schedules=False: we're on the WS event loop — schedule
+                    # fetching is blocking HTTP and is deferred to the REST thread.
+                    update_parks_operating_status([park], fetch_schedules=False)
+                return
 
 
 async def _ws_loop(api_key, parks_data):
@@ -153,10 +155,10 @@ async def _ws_loop(api_key, parks_data):
                                         "keeping existing data."
                                     )
                                 else:
-                                    park["live_data_stale"] = False
-                                    park["attractions"] = merge_live_data(park["attractions"], new_live_data)
-                        updated = update_parks_operating_status(list(parks_data), fetch_schedules=False)
-                        parks_data[:] = updated
+                                    with parks_data_lock:
+                                        park["live_data_stale"] = False
+                                        merge_live_data(park["attractions"], new_live_data)
+                        update_parks_operating_status(list(parks_data), fetch_schedules=False)
                         debug.info("REST refresh after reconnect complete.")
                     else:
                         debug.info("WebSocket connected to ThemeParks.wiki")


### PR DESCRIPTION
## Summary

Stacked on #74 (→ #73 → #72). Final piece of the WS resilience series: eliminates cross-thread lost updates on the shared `parks_data` structure.

### The bug class
Three threads touch `parks_data` concurrently: the WS thread mutates attraction dicts per event, the REST thread merges refreshes and replaces list contents, and the display thread reads. `merge_live_data` previously **rebuilt the attractions list**, so a WS update landing mid-merge wrote to a dict the merge was about to discard — the attraction silently kept a stale wait time until its next event.

### Changes
- **`merge_live_data` mutates in place** and returns the same list and dict objects (identity-tested). This removes the lost-update window at its source rather than just narrowing it.
- **`updater/shared.py` adds `parks_data_lock`**, held only for in-memory writes (microseconds): `_apply_live_update`'s dict writes, both merge sites (REST poll + WS reconnect refresh), and the REST thread's `parks_data[:]` replacements. Never held across HTTP calls, so it cannot stall the WS event loop or trigger false ping timeouts.
- **Display thread reads lock-free by design** — a torn read costs one frame of slightly inconsistent pixels; taking a lock in the render loop isn't worth the contention. Documented in `shared.py`.
- Dropped a redundant `parks_data[:]` reassignment in the reconnect path (`update_parks_operating_status` mutates the same park dicts it's given).

### Known remaining races (accepted)
`update_parks_operating_status` with `fetch_schedules=True` runs on the REST thread without the lock (it does blocking HTTP). A concurrent WS status flip can transiently disagree with it on `operating`; it self-corrects on the next event or poll cycle and never corrupts state.

## Testing
- 180 tests pass (4 new): merge identity/in-place semantics, lock acquisition in `_apply_live_update` and `update_parks_live_data` via spy lock, no lock churn for non-livedata events.
- Emulator smoke run: connects, subscribes, initial fetch and WS handoff unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)